### PR TITLE
SYS-961: Add view name parameter and refactor secret handling in primo-zip.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This repo may be deployed to Primo VE at https://ucla.alma.exlibrisgroup.com/SAM
 A *premium sandbox* (PSB), copied from production, is at https://sandbox02-na.alma.exlibrisgroup.com/institution/01UCS_LAL).
 
 Note: Deployment to either target is a manual process - this repo is used for source control.
-        This repo is defaulted for deployment to Production. Make the changes noted below for deployment to Test.
 
 **Workflow**
 
@@ -36,28 +35,29 @@ Structure of a typical ```secrets.json``` file
 
 Deploy to Test:
 
-    - locally, rename the top level folder from ```01UCS_LAL-UCLA``` to ```01UCS_LAL-Test_00```
-    - run the ```primo-zip.py``` script on the command line
-    ```>python3 primo-zip.py```
-    - note: ```01UCS_LAL-Test_00.zip``` is created (or updated) with secrets in place; secrets are then erased from the source code (from which the zip file was created)
-    - upload to the *Test_00* view using the Primo gui: https://ucla.alma.exlibrisgroup.com/SAML
+    - locally, rename the top level folder from ```01UCS_LAL-UCLA``` to the name of the test view you will use
+    - run the ```primo-zip.py``` script on the command line, using the desired view's name as a parameter, e.g.
+    ```>python3 primo-zip.py 01UCS_LAL-TEST_DEV```
+        - note: the view name specified here must match the name of the top-level folder
+    - note: ```01UCS_LAL-TEST_DEV``` is created (or updated) with secrets in place; secrets are then erased from the source code (from which the zip file was created)
+    - upload to the desired test view using the Primo gui: https://ucla.alma.exlibrisgroup.com/SAML
     - delete the folder and zip file before continuing editing or using git
     - delete the secrets.json file before using git
       - this is a good precaution even though ```*secrets*``` is in the ```.gitignore``` file
     - repeat the copy and zip before each deploy to the Test system
-    - reset to Production by renaming the top level folder from ```01UCS_LAL-Test_00``` to ```01UCS_LAL-UCLA```
+    - reset to Production by renaming the top level folder to ```01UCS_LAL-UCLA```
 
 Deploy to Production
 
     - ensure that the top level folder is named 01UCS_LAL-UCLA
-    - delete any Test folders or zip files: ```01UCS_LAL-Test_00``` and/or ```01UCS_LAL-Test_00.zip```
-    - run the ```primo-zip.py``` script on the command line
-    ```>python3 primo-zip.py```
-    - note: ```01UCS_LAL-UCLA.zip``` created (or updated) with secrets in place; secrets are then erased from the source code (from which the zip file was created)
-    - upload to the *UCLA* view using the Primo gui: https://ucla.alma.exlibrisgroup.com/SAML
+    - delete any Test folders or zip files
+    - run the ```primo-zip.py``` script on the command line, using the production's view name as a parameter
+    ```>python3 primo-zip.py 01UCS_LAL-UCLA```
+    - note: ```01UCS_LAL-UCLA.zip``` is created (or updated) with secrets in place; secrets are then erased from the source code (from which the zip file was created)
+    - upload to the production view using the Primo gui: https://ucla.alma.exlibrisgroup.com/SAML
     - delete the folder and zip file before continuing editing or using git
     - delete the secrets.json file before using git
       - this is a good precaution even though ```*secrets*``` is in the ```.gitignore``` file
     - repeat zip before each deploy to the Test system
 
-Note: Any Alma Primo VE gui settings that are changed in the *Test_00* GUI view must be transferred by hand to the *UCLA* GUI view.
+Note: Any Alma Primo VE gui settings that are changed in the test view's GUI must be transferred by hand to the *UCLA* view GUI.

--- a/primo-zip.py
+++ b/primo-zip.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 
-def swap_secrets_and_values(secret_data, types_to_check, directory, secret_visible=True):
+def swap_secrets_and_values(secret_data, types_to_check, directory, secret_visible):
 
     # var for file paths list
     file_paths = []
@@ -19,12 +19,9 @@ def swap_secrets_and_values(secret_data, types_to_check, directory, secret_visib
                 file_paths.append(filepath)
 
                 # find and replace each secret tag with the actual secret
-                cnt = 0
-                for i in secret_data['secret_details']:
-                    secret_name = str(
-                        secret_data['secret_details'][cnt]['secret_name'])
-                    secret_value = str(
-                        secret_data['secret_details'][cnt]['secret_value'])
+                for secret in secret_data['secret_details']:
+                    secret_name = secret['secret_name']
+                    secret_value = secret['secret_value']
 
                     with fileinput.FileInput(filepath, inplace=True) as file:
                         for line in file:
@@ -34,7 +31,6 @@ def swap_secrets_and_values(secret_data, types_to_check, directory, secret_visib
                                 print(line.replace(secret_name, secret_value), end='')
                             else:
                                 print(line.replace(secret_value, secret_name), end='')
-                    cnt += 1
 
 
 def zip_up_source(zip_name, base_directory, directory):
@@ -53,6 +49,8 @@ def main():
     types_to_check = ('.js', '.css', 'html', 'md', 'txt')
     base_directory = '.'
     directory = './' + zip_name
+    if not os.path.isdir(directory):
+        sys.exit("Folder name parameter must match top-level directory name.")
 
     # source of the secrets
     secrets = open('secrets.json')
@@ -61,14 +59,14 @@ def main():
 
     # find each file in dir structure, replace tags with secrets
     swap_secrets_and_values(secret_data, types_to_check,
-                            directory, secret_visible=True)
+                            directory, True)
 
     # zip the source for deploymeny to Primo
     zip_up_source(zip_name, base_directory, directory)
 
     # find each file in dir structure, replace secrets with tags
     swap_secrets_and_values(secret_data, types_to_check,
-                            directory, secret_visible=False)
+                            directory, False)
 
     print('Secrets inserted and files zipped: ' + zip_name + '.zip')
     print('Secrets cleared: code may now be pushed')

--- a/primo-zip.py
+++ b/primo-zip.py
@@ -59,14 +59,14 @@ def main():
 
     # find each file in dir structure, replace tags with secrets
     swap_secrets_and_values(secret_data, types_to_check,
-                            directory, True)
+                            directory, secret_visible=True)
 
     # zip the source for deploymeny to Primo
     zip_up_source(zip_name, base_directory, directory)
 
     # find each file in dir structure, replace secrets with tags
     swap_secrets_and_values(secret_data, types_to_check,
-                            directory, False)
+                            directory, secret_visible=False)
 
     print('Secrets inserted and files zipped: ' + zip_name + '.zip')
     print('Secrets cleared: code may now be pushed')

--- a/primo-zip.py
+++ b/primo-zip.py
@@ -3,9 +3,10 @@ import shutil
 import fileinput
 import json
 import os
+import sys
 
 
-def swap_secrets_and_values(secret_data, types_to_check, directory, secret_visible=1):
+def swap_secrets_and_values(secret_data, types_to_check, directory, secret_visible=True):
 
     # var for file paths list
     file_paths = []
@@ -25,13 +26,14 @@ def swap_secrets_and_values(secret_data, types_to_check, directory, secret_visib
                     secret_value = str(
                         secret_data['secret_details'][cnt]['secret_value'])
 
-                    secret_swap = [secret_name, secret_value]
                     with fileinput.FileInput(filepath, inplace=True) as file:
                         for line in file:
-                            # Replaces secret_name with secret_value when secret_visible = 1;
-                            #  replaces secret_value with secret_name when secret_visible = 0
-                            print(line.replace(
-                                str(secret_swap[1-secret_visible]), secret_swap[secret_visible]), end='')
+                            # Replaces secret_name with secret_value when secret_visible is True
+                            # Replaces secret_value with secret_name when secret_visible is False
+                            if secret_visible:
+                                print(line.replace(secret_name, secret_value), end='')
+                            else:
+                                print(line.replace(secret_value, secret_name), end='')
                     cnt += 1
 
 
@@ -41,19 +43,16 @@ def zip_up_source(zip_name, base_directory, directory):
 
 
 def main():
+    # user must input zip_name parameter at command line
+    if len(sys.argv) > 1:
+        zip_name = sys.argv[1]
+    else:
+        sys.exit("Folder name parameter must be specified.")
+
     # zip info
     types_to_check = ('.js', '.css', 'html', 'md', 'txt')
     base_directory = '.'
-    directory = './01UCS_LAL-UCLA'
-    directory_test = './01UCS_LAL-Test_00'
-    zip_name = '01UCS_LAL-UCLA'
-    zip_name_test = '01UCS_LAL-Test_00'
-
-    # use the test folder if it is present
-    isdir = os.path.isdir(directory_test)
-    if(isdir):
-        directory = directory_test
-        zip_name = zip_name_test
+    directory = './' + zip_name
 
     # source of the secrets
     secrets = open('secrets.json')
@@ -62,14 +61,14 @@ def main():
 
     # find each file in dir structure, replace tags with secrets
     swap_secrets_and_values(secret_data, types_to_check,
-                            directory, secret_visible=1)
+                            directory, secret_visible=True)
 
     # zip the source for deploymeny to Primo
     zip_up_source(zip_name, base_directory, directory)
 
     # find each file in dir structure, replace secrets with tags
     swap_secrets_and_values(secret_data, types_to_check,
-                            directory, secret_visible=0)
+                            directory, secret_visible=False)
 
     print('Secrets inserted and files zipped: ' + zip_name + '.zip')
     print('Secrets cleared: code may now be pushed')


### PR DESCRIPTION
Connected to [SYS-961](https://jira.library.ucla.edu/browse/SYS-961)

Changed files:
* primo-zip.py
* README.md

Script now requires command line parameter (matching name of top-level folder) to set view name. Hard-coded view names have been removed, and "secret swap" portion of the code has been refactored to improve readability. Readme has also been updated to reflect new script usage.
