### PR TITLE
SYS-954: Expand item record sidebar

### DIFF
--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -373,6 +373,6 @@ prm-full-view .services-index-under .md-button {
 prm-full-view .services-index-under #services-index{
   max-width: 180px;
 }
-prm-full-view .full-view-section {
+.full-view-section {
   padding-left: 4em;
 }

--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -365,3 +365,14 @@ prm-stand-alone-login .md-button:hover:not([disabled]) {
 prm-stand-alone-login prm-login form > div .md-button:hover:not([disabled]) md-icon.md-primoExplore-theme {
   color: var(--color-secondary-blue-03) !important;
 }
+
+/* sidebar in detail results */
+prm-full-view .services-index-under .md-button {
+  max-width: 180px;
+}
+prm-full-view .services-index-under #services-index{
+  max-width: 180px;
+}
+prm-full-view .full-view-section {
+  padding-left: 4em;
+}


### PR DESCRIPTION
Relates to [SYS-954](https://jira.library.ucla.edu/browse/SYS-954)
Files changed: 01UCS_LAL-UCLA/css/custom1.css

On the full results page for an item, sidebar is now wide enough for full "Related Resources" text. Tested on desktop, tablet, and mobile (no change for mobile since sidebar isn't visible).