### PR TITLE
SYS-957: change back-to-search icon to single caret

### DIFF
--- a/01UCS_LAL-UCLA/img/custom-ui.svg
+++ b/01UCS_LAL-UCLA/img/custom-ui.svg
@@ -1,2 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="5000" viewBox="0 0 24 5000">
-</svg>
+<svg id="back-to-search" viewBox="0 0 24 24">
+<path xmlns="http://www.w3.org/2000/svg" d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"/>
+</svg></svg>


### PR DESCRIPTION
Relates to [SYS-957](https://jira.library.ucla.edu/browse/SYS-957)

Available in test view: [https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_957](https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_957) 

If change is not visible immediately, try clearing browser cache.