### PR TITLE
SYS-956: Revert SYS-956 CSS changes to fix advanced search on home page

### DIFF
--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -394,18 +394,3 @@ md-autocomplete-parent-scope {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
-/* increase width of request form */
-.layout-align-start-stretch, md-input-container, md-input-container .md-input, .md-datepicker-input{
-  width: 100%;
-}  
-.md-datepicker-input {
-  max-width: 500px
-}
-.md-datepicker-input-container {
-  width: 100%;
-  margin-left: -34px !important;
-}
-._md-datepicker-floating-label._md-datepicker-has-calendar-icon md-datepicker .md-datepicker-button {
-  left: -34px 
-}


### PR DESCRIPTION
Advanced search reported broken by Miki - undoing CSS changes that used same selectors to restyle different form.