### PR TITLE
SYS-956: Widen request form fields

### DIFF
--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -394,3 +394,20 @@ md-autocomplete-parent-scope {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* increase width of item request form */
+.layout-align-start-stretch, #form_field_pickupLocation .underlined-input, 
+#form_field_termsOfUse .underlined-input, #form_field_comment .underlined-input, 
+md-input-container .md-input, .md-datepicker-input {
+  width: 100%;
+} 
+.md-datepicker-input {
+  max-width: 500px
+}
+.md-datepicker-input-container {
+  width: 100%;
+  margin-left: -34px !important;
+}
+._md-datepicker-floating-label._md-datepicker-has-calendar-icon md-datepicker .md-datepicker-button {
+  left: -34px 
+}


### PR DESCRIPTION
Relates to [SYS-956](https://jira.library.ucla.edu/browse/SYS-956)
Available in test view: [SYS-956 test view](https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_956)

Tested more thoroughly this time - no changes seen to any other forms (basic and advanced search, ILL request, LibAnswers). Below text is same as previous PR (PR #11).

An example to use for testing can be seen in [this link to the test view](https://search.library.ucla.edu/discovery/fulldisplay?context=L&vid=01UCS_LAL:UCLA_SYS_956&search_scope=ArticlesBooksMore&tab=Articles_books_more_slot&docid=alma9924703053606533&lang=en). For comparison, here is [the same item in the current production view](https://search.library.ucla.edu/discovery/fulldisplay?context=L&vid=01UCS_LAL:UCLA&search_scope=ArticlesBooksMore&tab=Articles_books_more_slot&docid=alma9924703053606533&lang=en).

You will need to sign in, then find the SRLF entry in Related Titles under How to Get It. Click this, then click Request on one of the newly visible items. (In both the current and new views, the Request link is poorly positioned on mobile - this ticket does not affect that). The resulting form should have longer fields.

Tested on desktop (Mac: Chrome, Firefox) and mobile (Browerstack - iPhone 12: Chrome, Safari; Pixel 4: Chrome, Firefox)