### PR TITLE
SYS-995: Fix holdings filter dropdown formatting

### DIFF
--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -396,7 +396,7 @@ md-autocomplete-parent-scope {
 }
 
 /* increase width of item request form */
-.layout-align-start-stretch, #form_field_pickupLocation .underlined-input, 
+#tab-content-40 .layout-align-start-stretch, #form_field_pickupLocation .underlined-input, 
 #form_field_termsOfUse .underlined-input, #form_field_comment .underlined-input, 
 md-input-container .md-input, .md-datepicker-input {
   width: 100%;


### PR DESCRIPTION
Related to [SYS-995](https://jira.library.ucla.edu/browse/SYS-995)
Available in a test view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_995

After [SYS-956](https://jira.library.ucla.edu/browse/SYS-956)/PR #13, users noticed a display issue when attempting to filter the holdings listings for a Primo record. This PR fixes that issue by further increasing the CSS selector specificity. Search, advanced search, blank ILL, item request, and holdings filtering forms have been tested with the new view (in Firefox on Mac and Chrome on Android). 

Quick links to test records in new view:
[Item request form example](https://search.library.ucla.edu/discovery/fulldisplay?context=L&vid=01UCS_LAL:UCLA_SYS_995&search_scope=ArticlesBooksMore&tab=Articles_books_more_slot&docid=alma9924703053606533) - after login, choose the SRLF related title and click "Request" on a resulting entry
[Location filter example](https://search.library.ucla.edu/discovery/fulldisplay?docid=alma9975085553606533&context=L&vid=01UCS_LAL:UCLA_SYS_995&lang=en) - click the filter icon next to "Location"