### PR TITLE
SYS-1033: Add spacing between fields in full item display

### DIFF
--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -416,3 +416,6 @@ md-input-container .md-input, .md-datepicker-input {
 .word-break.layout-column[role=listitem] {
   margin-top: 4px;
 }
+.flex-gt-xs-25.flex-gt-sm-20.flex{
+  margin-top: 4px;
+}

--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -31,71 +31,42 @@
   --color-visit-fushia-03: #ff94db;
   --color-about-purple-03: #c099ff;
 }
-
 /*Top Banner Background Color */
-.prm-primary-bg.prm-hue1,
-prm-spinner.prm-hue1.overlay-cover.light-on-dark:after,
-prm-topbar .top-nav-bar,
-prm-search-bar.prm-hue1 {
-  background-color: var(--color-primary-blue-04);
-}
-
-.prm-primary-bg.prm-hue1,
-prm-search-bar.prm-hue1,
-prm-spinner.prm-hue1.overlay-cover.light-on-dark:after,
-prm-topbar .top-nav-bar {
-  background-color: #003B5C;
-}
+.prm-primary-bg.prm-hue1, prm-spinner.prm-hue1.overlay-cover.light-on-dark:after, prm-topbar .top-nav-bar, prm-search-bar.prm-hue1 {background-color: var(--color-primary-blue-04); }
+.prm-primary-bg.prm-hue1, prm-search-bar.prm-hue1, prm-spinner.prm-hue1.overlay-cover.light-on-dark:after, prm-topbar .top-nav-bar{background-color: #003B5C; }
 
 /*!!!!!!!  TOPBAR - USER AREA - HOVER COLOR !!!!!!!!*/
-md-fab-toolbar md-toolbar {
-  background-color: var(--color-primary-blue-04) !important;
-  pointer-events: none;
-  z-index: 23;
-}
-
+  md-fab-toolbar md-toolbar {
+      background-color: var(--color-primary-blue-04) !important;
+      pointer-events: none;
+      z-index: 23;
+  }
 /*Search Bar Wrapper color */
-prm-search-bar,
-prm-atoz-search-bar,
-prm-journals-search-bar,
-prm-browse-search-bar,
-prm-tags-search-bar,
-.prm-primary-bg,
-prm-collection-gallery-header .collection-header-inner,
-prm-newspapers-search-bar,
-prm-spinner.overlay-cover.light-on-dark:after {
-  background-color: var(--color-primary-blue-03);
-}
-
+  prm-search-bar, prm-atoz-search-bar, prm-journals-search-bar, prm-browse-search-bar, prm-tags-search-bar, .prm-primary-bg, prm-collection-gallery-header .collection-header-inner, prm-newspapers-search-bar, prm-spinner.overlay-cover.light-on-dark:after{
+    background-color: var(--color-primary-blue-03);
+ }
 /*Remove blue line underneath image on hover */
-prm-logo .product-logo a:hover {
-  background-color: transparent;
-  text-transform: none;
-  box-shadow: none;
-}
-
+ prm-logo .product-logo a:hover {
+	background-color:transparent; text-transform:none; box-shadow: none;
+ }
 /*Hide library in the brief and full displays since Locations also contain the library name */
-span.best-location-library-code.locations-link {
-  display: none;
-}
-
-/*Hide location title in full view since per ticket 201804098  */
-prm-location-items .tab-content-header .md-title {
-  display: none;
-}
-
+ span.best-location-library-code.locations-link{
+	display: none;
+ }
+ /*Hide location title in full view since per ticket 201804098  */
+ prm-location-items .tab-content-header .md-title {
+   display: none;
+ }
 /* md-list-item.md-2-line .md-list-item-text h3 {
    display: none;
  }*/
 span[translate="nui.request.request"] {
-  display: none;
+  display:none;
 }
-
 /*match UCSC font*/
-body .header {
-  font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+body .header{
+    font-family: Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;
 }
-
 /*Hide 'Expand My Results' checkbox
 md-checkbox[aria-label="Expand My Results"]{
 display: none;
@@ -103,52 +74,37 @@ display: none;
 */
 /*Increase the width of the element that includes location and call number */
 div.flex-xs-100.flex {
-  min-width: fit-content;
+ min-width: fit-content;
 }
-
 /*Change sign-in, and ellipses link colors */
-md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text .list-item-title,
-md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text h3,
-prm-main-menu[menu-type="full"] md-card .md-headline,
-prm-user-area .user-menu-button .user-name {
+md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text .list-item-title, md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text h3, prm-main-menu[menu-type="full"] md-card .md-headline, prm-user-area .user-menu-button .user-name {
   color: var(--color-secondary-yellow-600);
 }
-
-prm-main-menu[menu-type="full"] .md-button .md-headline,
-prm-main-menu[menu-type="full"] .overlay-menu-item .md-headline {
-  color: var(--color-secondary-yellow-600) !important;
+prm-main-menu[menu-type="full"] .md-button .md-headline, prm-main-menu[menu-type="full"] .overlay-menu-item .md-headline {
+    color: var(--color-secondary-yellow-600) !important;
 }
-
 .header prm-user-area-expandable .md-button.user-button {
   color: var(--color-secondary-yellow-600);
 }
-
 /* change color of magnifying glass in search bar */
-div.search-actions button.md-button.button-confirm,
-div.search-actions button.md-button.button-confirm prm-icon {
+div.search-actions button.md-button.button-confirm, div.search-actions button.md-button.button-confirm prm-icon{
   color: var(--color-secondary-yellow-600) !important;
 }
-
 .search-actions .md-button.button-confirm:hover:not([disabled]) {
   background-color: rgba(231, 245, 15, 0.45);
 }
-
 /*Change sign-in link colors for standalone login*/
-.login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link1"],
-.login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link2"] {
+.login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link1"], .login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link2"] {
   color: var(--color-secondary-yellow-600) !important;
 }
-
 prm-stand-alone-login div.login-header {
   background-color: var(--color-primary-blue-04);
 }
-
-prm-stand-alone-login prm-icon md-icon svg {
+prm-stand-alone-login prm-icon md-icon svg{
   color: var(--color-white) !important;
 }
-
 /*bookplate*/
-.bookplate {
+.bookplate{
   background-color: var(--color-primary-blue-04);
   text-align: center;
   color: var(--color-white);
@@ -157,102 +113,80 @@ prm-stand-alone-login prm-icon md-icon svg {
   font-family: Didot, serif;
   border: 3px double white;
 }
-
 button.bookplateBtn {
   border: 1px solid var(--color-primary-blue-04);
 }
-
 .bookplateLink {
-  display: table;
-  padding: 5px;
+  display:table;
+  padding:5px;
   border: 2px solid var(--color-secondary-yellow-600);
 }
-
 .bookplateLinkText {
-  display: table-cell;
+  display:table-cell;
   vertical-align: middle;
   font-weight: bold;
 }
-
 div.full-view-section {
   margin-top: 0 !important;
 }
-
 /*disable new sign in*/
 prm-user-area {
   /*display:block!important;*/
 }
-
 prm-user-area-expandable {
-  /*display:none!important;*/
+    /*display:none!important;*/
 }
-
 /*hide rss button on saved searches*/
 div.saved-query-actions svg#rss {
   display: none;
 }
-
 /*hide sign-in banner*/
 prm-explore-main .alert-bar {
   /*display:none;*/
 }
-
 /* CSS for vpn popup */
 .vpnButton {
-  width: 100%;
+  width:100%;
 }
-
 .vpnButton p {
   text-align: center;
 }
-
 .vpnButton .md-button {
   color: white;
   background: var(--color-secondary-blue-03);
   overflow-x: hidden !important;
   white-space: pre-wrap !important;
 }
-
 /*update css for color contrast */
-prm-search-result-availability-line div.layout-row div.layout-row button.neutralized-button span.button-content span.availability-status.unavailable {
-  color: var(--color-secondary-grey-05) !important;
+prm-search-result-availability-line div.layout-row div.layout-row button.neutralized-button span.button-content span.availability-status.unavailable{
+    color: var(--color-secondary-grey-05) !important;
 }
-
 prm-virtual-browse-item p span.weak-text {
-  color: var(--color-secondary-grey-05) !important;
+    color: var(--color-secondary-grey-05) !important;
 }
-
 /* change color of check at status*/
 .availability-status.Check.at {
   color: #0f7d00 !important;
 }
-
 /* make call number more visible */
-.full-view-container .best-location-sub-location,
-.full-view-container .best-location-delivery {
+.full-view-container .best-location-sub-location,.full-view-container .best-location-delivery {
   font-weight: bold;
 }
-
-.full-view-container .md-list-item-text p span.availability-status~span {
+.full-view-container .md-list-item-text p span.availability-status ~ span{
   font-weight: bold !important;
 }
-
-.full-view-container .md-list-item-text p span.availability-status+span {
+.full-view-container .md-list-item-text p span.availability-status + span{
   display: none !important;
 }
-
-.full-view-container prm-location-items .layout-column p span.availability-status+span {
+.full-view-container prm-location-items .layout-column p span.availability-status + span{
   display: none !important;
 }
-
-.full-view-container prm-location-items .layout-column p span.availability-status~span {
+.full-view-container prm-location-items .layout-column p span.availability-status ~ span{
   font-weight: bold !important;
 }
-
 .HTLink {
   font-weight: bold !important;
 }
-
 /* make ellipses modal lighter */
 md-dialog.light-on-dark-dialog {
   background-color: var(--color-primary-blue-05) !important;
@@ -263,25 +197,20 @@ md-dialog.light-on-dark-dialog {
 .uc-library-search-logo {
   display: none;
 }
-
 /* no hover effect */
 .uc-library-search-logo button {
-  background: transparent !important;
+  background: transparent!important;
 }
-
 @media (min-width: 970px) {
   .search-wrapper {
     margin-left: 20%;
   }
-
   .search-wrapper .flex-lg-10 {
     display: none;
   }
-
   .search-wrapper .flex-lg-65 {
     max-width: 80%;
   }
-
   .uc-library-search-logo {
     display: block;
     width: 20%;
@@ -289,23 +218,19 @@ md-dialog.light-on-dark-dialog {
     top: 30px;
     position: absolute;
   }
-
   .uc-library-search-logo button {
     margin-top: 0;
   }
-
   .uc-library-search-logo img {
     width: 70%;
     max-width: 300px;
   }
 }
-
 @media (min-width: 1300px) {
   .uc-library-search-logo {
     top: 1.5em;
   }
 }
-
 /* External search: worldcat */
 /*
 div[data-facet-group="External Search"] h3 {
@@ -315,41 +240,35 @@ div[data-facet-group="External Search"] h3 {
 #external-search .md-chip {
   margin-bottom: 5px;
 }
-
 #external-search img {
   float: left;
   margin-right: 8px;
 }
-
 #external-search a {
   font-weight: bold;
 }
-
 #external-search span {
   display: block;
   color: var(--color-secondary-grey-05);
 }
-
 /* View Main Menu on the services page / openURL page */
 prm-main-menu.isServicePage {
   display: block !important;
 }
-
-.search-result-availability-line-wrapper {
+.search-result-availability-line-wrapper{
   min-height: 2.4em;
   z-index: 1;
 }
 
 .browzine {
   padding-left: 25px;
-}
-
-prm-logo .logo-image,
-prm-logo img {
-  max-height: 100%;
-  transform: scale(1.3);
-  padding-left: 0px;
-}
+  }
+  
+  prm-logo .logo-image, prm-logo img {
+    max-height: 100%;
+    transform: scale(1.3);
+    padding-left: 0px;
+  }
 
 /* modal login */
 md-dialog.light-on-dark-dialog {
@@ -366,8 +285,8 @@ md-dialog.light-on-dark-dialog md-list md-list-item.list-login .md-button:focus:
 
 .login-dialog md-list md-list-item .md-list-item-text .list-item-title,
 .login-dialog md-list md-list-item .md-list-item-text h3,
-.login-dialog md-list md-list-item>.md-no-style .md-list-item-text .list-item-title,
-.login-dialog md-list md-list-item>.md-no-style .md-list-item-text h3,
+.login-dialog md-list md-list-item > .md-no-style .md-list-item-text .list-item-title,
+.login-dialog md-list md-list-item > .md-no-style .md-list-item-text h3,
 .light-on-dark-dialog .md-button.button-confirm {
   color: var(--color-white) !important;
 }
@@ -443,7 +362,7 @@ prm-stand-alone-login .md-button:hover:not([disabled]) {
   color: var(--color-secondary-blue-03);
 }
 
-prm-stand-alone-login prm-login form>div .md-button:hover:not([disabled]) md-icon.md-primoExplore-theme {
+prm-stand-alone-login prm-login form > div .md-button:hover:not([disabled]) md-icon.md-primoExplore-theme {
   color: var(--color-secondary-blue-03) !important;
 }
 
@@ -451,11 +370,9 @@ prm-stand-alone-login prm-login form>div .md-button:hover:not([disabled]) md-ico
 prm-full-view .services-index-under .md-button {
   max-width: 180px;
 }
-
-prm-full-view .services-index-under #services-index {
+prm-full-view .services-index-under #services-index{
   max-width: 180px;
 }
-
 .full-view-section {
   padding-left: 4em;
 }
@@ -464,11 +381,9 @@ prm-full-view .services-index-under #services-index {
 prm-icon.giant-icon md-icon {
   display: none
 }
-
 md-tab-content {
   transition: unset !important
 }
-
 md-ink-bar {
   transition: unset !important
 }
@@ -481,26 +396,20 @@ md-autocomplete-parent-scope {
 }
 
 /* increase width of item request form */
-#tab-content-40 .layout-align-start-stretch,
-#form_field_pickupLocation .underlined-input,
-#form_field_termsOfUse .underlined-input,
-#form_field_comment .underlined-input,
-md-input-container .md-input,
-.md-datepicker-input {
+#tab-content-40 .layout-align-start-stretch, #form_field_pickupLocation .underlined-input, 
+#form_field_termsOfUse .underlined-input, #form_field_comment .underlined-input, 
+md-input-container .md-input, .md-datepicker-input {
   width: 100%;
-}
-
+} 
 .md-datepicker-input {
   max-width: 500px
 }
-
 .md-datepicker-input-container {
   width: 100%;
   margin-left: -34px !important;
 }
-
 ._md-datepicker-floating-label._md-datepicker-has-calendar-icon md-datepicker .md-datepicker-button {
-  left: -34px
+  left: -34px 
 }
 
 /* increase spacing in item detail lists */

--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -31,42 +31,71 @@
   --color-visit-fushia-03: #ff94db;
   --color-about-purple-03: #c099ff;
 }
+
 /*Top Banner Background Color */
-.prm-primary-bg.prm-hue1, prm-spinner.prm-hue1.overlay-cover.light-on-dark:after, prm-topbar .top-nav-bar, prm-search-bar.prm-hue1 {background-color: var(--color-primary-blue-04); }
-.prm-primary-bg.prm-hue1, prm-search-bar.prm-hue1, prm-spinner.prm-hue1.overlay-cover.light-on-dark:after, prm-topbar .top-nav-bar{background-color: #003B5C; }
+.prm-primary-bg.prm-hue1,
+prm-spinner.prm-hue1.overlay-cover.light-on-dark:after,
+prm-topbar .top-nav-bar,
+prm-search-bar.prm-hue1 {
+  background-color: var(--color-primary-blue-04);
+}
+
+.prm-primary-bg.prm-hue1,
+prm-search-bar.prm-hue1,
+prm-spinner.prm-hue1.overlay-cover.light-on-dark:after,
+prm-topbar .top-nav-bar {
+  background-color: #003B5C;
+}
 
 /*!!!!!!!  TOPBAR - USER AREA - HOVER COLOR !!!!!!!!*/
-  md-fab-toolbar md-toolbar {
-      background-color: var(--color-primary-blue-04) !important;
-      pointer-events: none;
-      z-index: 23;
-  }
+md-fab-toolbar md-toolbar {
+  background-color: var(--color-primary-blue-04) !important;
+  pointer-events: none;
+  z-index: 23;
+}
+
 /*Search Bar Wrapper color */
-  prm-search-bar, prm-atoz-search-bar, prm-journals-search-bar, prm-browse-search-bar, prm-tags-search-bar, .prm-primary-bg, prm-collection-gallery-header .collection-header-inner, prm-newspapers-search-bar, prm-spinner.overlay-cover.light-on-dark:after{
-    background-color: var(--color-primary-blue-03);
- }
+prm-search-bar,
+prm-atoz-search-bar,
+prm-journals-search-bar,
+prm-browse-search-bar,
+prm-tags-search-bar,
+.prm-primary-bg,
+prm-collection-gallery-header .collection-header-inner,
+prm-newspapers-search-bar,
+prm-spinner.overlay-cover.light-on-dark:after {
+  background-color: var(--color-primary-blue-03);
+}
+
 /*Remove blue line underneath image on hover */
- prm-logo .product-logo a:hover {
-	background-color:transparent; text-transform:none; box-shadow: none;
- }
+prm-logo .product-logo a:hover {
+  background-color: transparent;
+  text-transform: none;
+  box-shadow: none;
+}
+
 /*Hide library in the brief and full displays since Locations also contain the library name */
- span.best-location-library-code.locations-link{
-	display: none;
- }
- /*Hide location title in full view since per ticket 201804098  */
- prm-location-items .tab-content-header .md-title {
-   display: none;
- }
+span.best-location-library-code.locations-link {
+  display: none;
+}
+
+/*Hide location title in full view since per ticket 201804098  */
+prm-location-items .tab-content-header .md-title {
+  display: none;
+}
+
 /* md-list-item.md-2-line .md-list-item-text h3 {
    display: none;
  }*/
 span[translate="nui.request.request"] {
-  display:none;
+  display: none;
 }
+
 /*match UCSC font*/
-body .header{
-    font-family: Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;
+body .header {
+  font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
+
 /*Hide 'Expand My Results' checkbox
 md-checkbox[aria-label="Expand My Results"]{
 display: none;
@@ -74,37 +103,52 @@ display: none;
 */
 /*Increase the width of the element that includes location and call number */
 div.flex-xs-100.flex {
- min-width: fit-content;
+  min-width: fit-content;
 }
+
 /*Change sign-in, and ellipses link colors */
-md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text .list-item-title, md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text h3, prm-main-menu[menu-type="full"] md-card .md-headline, prm-user-area .user-menu-button .user-name {
+md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text .list-item-title,
+md-dialog.light-on-dark-dialog md-list md-list-item .md-list-item-text h3,
+prm-main-menu[menu-type="full"] md-card .md-headline,
+prm-user-area .user-menu-button .user-name {
   color: var(--color-secondary-yellow-600);
 }
-prm-main-menu[menu-type="full"] .md-button .md-headline, prm-main-menu[menu-type="full"] .overlay-menu-item .md-headline {
-    color: var(--color-secondary-yellow-600) !important;
+
+prm-main-menu[menu-type="full"] .md-button .md-headline,
+prm-main-menu[menu-type="full"] .overlay-menu-item .md-headline {
+  color: var(--color-secondary-yellow-600) !important;
 }
+
 .header prm-user-area-expandable .md-button.user-button {
   color: var(--color-secondary-yellow-600);
 }
+
 /* change color of magnifying glass in search bar */
-div.search-actions button.md-button.button-confirm, div.search-actions button.md-button.button-confirm prm-icon{
+div.search-actions button.md-button.button-confirm,
+div.search-actions button.md-button.button-confirm prm-icon {
   color: var(--color-secondary-yellow-600) !important;
 }
+
 .search-actions .md-button.button-confirm:hover:not([disabled]) {
   background-color: rgba(231, 245, 15, 0.45);
 }
+
 /*Change sign-in link colors for standalone login*/
-.login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link1"], .login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link2"] {
+.login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link1"],
+.login-dialog md-list md-list-item .md-list-item-text h3[translate="parallel.login.link2"] {
   color: var(--color-secondary-yellow-600) !important;
 }
+
 prm-stand-alone-login div.login-header {
   background-color: var(--color-primary-blue-04);
 }
-prm-stand-alone-login prm-icon md-icon svg{
+
+prm-stand-alone-login prm-icon md-icon svg {
   color: var(--color-white) !important;
 }
+
 /*bookplate*/
-.bookplate{
+.bookplate {
   background-color: var(--color-primary-blue-04);
   text-align: center;
   color: var(--color-white);
@@ -113,80 +157,102 @@ prm-stand-alone-login prm-icon md-icon svg{
   font-family: Didot, serif;
   border: 3px double white;
 }
+
 button.bookplateBtn {
   border: 1px solid var(--color-primary-blue-04);
 }
+
 .bookplateLink {
-  display:table;
-  padding:5px;
+  display: table;
+  padding: 5px;
   border: 2px solid var(--color-secondary-yellow-600);
 }
+
 .bookplateLinkText {
-  display:table-cell;
+  display: table-cell;
   vertical-align: middle;
   font-weight: bold;
 }
+
 div.full-view-section {
   margin-top: 0 !important;
 }
+
 /*disable new sign in*/
 prm-user-area {
   /*display:block!important;*/
 }
+
 prm-user-area-expandable {
-    /*display:none!important;*/
+  /*display:none!important;*/
 }
+
 /*hide rss button on saved searches*/
 div.saved-query-actions svg#rss {
   display: none;
 }
+
 /*hide sign-in banner*/
 prm-explore-main .alert-bar {
   /*display:none;*/
 }
+
 /* CSS for vpn popup */
 .vpnButton {
-  width:100%;
+  width: 100%;
 }
+
 .vpnButton p {
   text-align: center;
 }
+
 .vpnButton .md-button {
   color: white;
   background: var(--color-secondary-blue-03);
   overflow-x: hidden !important;
   white-space: pre-wrap !important;
 }
+
 /*update css for color contrast */
-prm-search-result-availability-line div.layout-row div.layout-row button.neutralized-button span.button-content span.availability-status.unavailable{
-    color: var(--color-secondary-grey-05) !important;
+prm-search-result-availability-line div.layout-row div.layout-row button.neutralized-button span.button-content span.availability-status.unavailable {
+  color: var(--color-secondary-grey-05) !important;
 }
+
 prm-virtual-browse-item p span.weak-text {
-    color: var(--color-secondary-grey-05) !important;
+  color: var(--color-secondary-grey-05) !important;
 }
+
 /* change color of check at status*/
 .availability-status.Check.at {
   color: #0f7d00 !important;
 }
+
 /* make call number more visible */
-.full-view-container .best-location-sub-location,.full-view-container .best-location-delivery {
+.full-view-container .best-location-sub-location,
+.full-view-container .best-location-delivery {
   font-weight: bold;
 }
-.full-view-container .md-list-item-text p span.availability-status ~ span{
+
+.full-view-container .md-list-item-text p span.availability-status~span {
   font-weight: bold !important;
 }
-.full-view-container .md-list-item-text p span.availability-status + span{
+
+.full-view-container .md-list-item-text p span.availability-status+span {
   display: none !important;
 }
-.full-view-container prm-location-items .layout-column p span.availability-status + span{
+
+.full-view-container prm-location-items .layout-column p span.availability-status+span {
   display: none !important;
 }
-.full-view-container prm-location-items .layout-column p span.availability-status ~ span{
+
+.full-view-container prm-location-items .layout-column p span.availability-status~span {
   font-weight: bold !important;
 }
+
 .HTLink {
   font-weight: bold !important;
 }
+
 /* make ellipses modal lighter */
 md-dialog.light-on-dark-dialog {
   background-color: var(--color-primary-blue-05) !important;
@@ -197,20 +263,25 @@ md-dialog.light-on-dark-dialog {
 .uc-library-search-logo {
   display: none;
 }
+
 /* no hover effect */
 .uc-library-search-logo button {
-  background: transparent!important;
+  background: transparent !important;
 }
+
 @media (min-width: 970px) {
   .search-wrapper {
     margin-left: 20%;
   }
+
   .search-wrapper .flex-lg-10 {
     display: none;
   }
+
   .search-wrapper .flex-lg-65 {
     max-width: 80%;
   }
+
   .uc-library-search-logo {
     display: block;
     width: 20%;
@@ -218,19 +289,23 @@ md-dialog.light-on-dark-dialog {
     top: 30px;
     position: absolute;
   }
+
   .uc-library-search-logo button {
     margin-top: 0;
   }
+
   .uc-library-search-logo img {
     width: 70%;
     max-width: 300px;
   }
 }
+
 @media (min-width: 1300px) {
   .uc-library-search-logo {
     top: 1.5em;
   }
 }
+
 /* External search: worldcat */
 /*
 div[data-facet-group="External Search"] h3 {
@@ -240,35 +315,41 @@ div[data-facet-group="External Search"] h3 {
 #external-search .md-chip {
   margin-bottom: 5px;
 }
+
 #external-search img {
   float: left;
   margin-right: 8px;
 }
+
 #external-search a {
   font-weight: bold;
 }
+
 #external-search span {
   display: block;
   color: var(--color-secondary-grey-05);
 }
+
 /* View Main Menu on the services page / openURL page */
 prm-main-menu.isServicePage {
   display: block !important;
 }
-.search-result-availability-line-wrapper{
+
+.search-result-availability-line-wrapper {
   min-height: 2.4em;
   z-index: 1;
 }
 
 .browzine {
   padding-left: 25px;
-  }
-  
-  prm-logo .logo-image, prm-logo img {
-    max-height: 100%;
-    transform: scale(1.3);
-    padding-left: 0px;
-  }
+}
+
+prm-logo .logo-image,
+prm-logo img {
+  max-height: 100%;
+  transform: scale(1.3);
+  padding-left: 0px;
+}
 
 /* modal login */
 md-dialog.light-on-dark-dialog {
@@ -285,8 +366,8 @@ md-dialog.light-on-dark-dialog md-list md-list-item.list-login .md-button:focus:
 
 .login-dialog md-list md-list-item .md-list-item-text .list-item-title,
 .login-dialog md-list md-list-item .md-list-item-text h3,
-.login-dialog md-list md-list-item > .md-no-style .md-list-item-text .list-item-title,
-.login-dialog md-list md-list-item > .md-no-style .md-list-item-text h3,
+.login-dialog md-list md-list-item>.md-no-style .md-list-item-text .list-item-title,
+.login-dialog md-list md-list-item>.md-no-style .md-list-item-text h3,
 .light-on-dark-dialog .md-button.button-confirm {
   color: var(--color-white) !important;
 }
@@ -362,7 +443,7 @@ prm-stand-alone-login .md-button:hover:not([disabled]) {
   color: var(--color-secondary-blue-03);
 }
 
-prm-stand-alone-login prm-login form > div .md-button:hover:not([disabled]) md-icon.md-primoExplore-theme {
+prm-stand-alone-login prm-login form>div .md-button:hover:not([disabled]) md-icon.md-primoExplore-theme {
   color: var(--color-secondary-blue-03) !important;
 }
 
@@ -370,9 +451,11 @@ prm-stand-alone-login prm-login form > div .md-button:hover:not([disabled]) md-i
 prm-full-view .services-index-under .md-button {
   max-width: 180px;
 }
-prm-full-view .services-index-under #services-index{
+
+prm-full-view .services-index-under #services-index {
   max-width: 180px;
 }
+
 .full-view-section {
   padding-left: 4em;
 }
@@ -381,9 +464,11 @@ prm-full-view .services-index-under #services-index{
 prm-icon.giant-icon md-icon {
   display: none
 }
+
 md-tab-content {
   transition: unset !important
 }
+
 md-ink-bar {
   transition: unset !important
 }
@@ -396,18 +481,29 @@ md-autocomplete-parent-scope {
 }
 
 /* increase width of item request form */
-#tab-content-40 .layout-align-start-stretch, #form_field_pickupLocation .underlined-input, 
-#form_field_termsOfUse .underlined-input, #form_field_comment .underlined-input, 
-md-input-container .md-input, .md-datepicker-input {
+#tab-content-40 .layout-align-start-stretch,
+#form_field_pickupLocation .underlined-input,
+#form_field_termsOfUse .underlined-input,
+#form_field_comment .underlined-input,
+md-input-container .md-input,
+.md-datepicker-input {
   width: 100%;
-} 
+}
+
 .md-datepicker-input {
   max-width: 500px
 }
+
 .md-datepicker-input-container {
   width: 100%;
   margin-left: -34px !important;
 }
+
 ._md-datepicker-floating-label._md-datepicker-has-calendar-icon md-datepicker .md-datepicker-button {
-  left: -34px 
+  left: -34px
+}
+
+/* increase spacing in item detail lists */
+[role=listitem] {
+  margin-top: 4px;
 }

--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -504,6 +504,6 @@ md-input-container .md-input,
 }
 
 /* increase spacing in item detail lists */
-[role=listitem] {
+.word-break.layout-column[role=listitem] {
   margin-top: 4px;
 }


### PR DESCRIPTION
Implements [SYS-1033](https://jira.library.ucla.edu/browse/SYS-1033)
Available in UCLA_SYS_1033 test view ([sample record link here](https://search.library.ucla.edu/discovery/fulldisplay?docid=alma9996860689906533&context=L&vid=01UCS_LAL:UCLA_SYS_1033&lang=en))

Adds a bit of space between listed items in record details (e.g. the many Notes on the record above). Should not change any other part of Primo. Tested in Firefox on MacOS and Chrome on Android. 