### PR TITLE
SYS-1077: Suppress "Search Inside" print-only journals

### DIFF
--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -419,3 +419,11 @@ md-input-container .md-input, .md-datepicker-input {
 .flex-gt-xs-25.flex-gt-sm-20.flex{
   margin-top: 4px;
 }
+
+/* Hide "search inside" for physical-only journals */
+.button-right-align.search-within-p-only {
+  display: none;
+  }
+#searchWithinJournal.search-within-p-only {
+  display: none;
+} 


### PR DESCRIPTION
Implements [SYS-1077](https://jira.library.ucla.edu/browse/SYS-1077)

Currently, Primo offers users the ability to "Search Inside" all records with an ISSN (i.e. serials). If we have electronic holdings for these records, the search works correctly and finds results in the contents of the serial. If we only have physical holdings, the search is still visible but will give no results.

This PR uses CSS to suppress this "Search Inside" function (the search box and sidebar link on an item detail record) for serials with only physical holdings. This is available in a test view here: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_1077&lang=en 

Example records:
- Current view
  - [Physical only journal](https://search.library.ucla.edu/permalink/01UCS_LAL/17p22dp/alma9939784173606533)
  - [Electronic journal](https://search.library.ucla.edu/permalink/01UCS_LAL/17p22dp/alma99461823606533)
- New view
  - [Physical only journal](https://search.library.ucla.edu/permalink/01UCS_LAL/85hnjm/alma9939784173606533)
  - [Electronic journal](https://search.library.ucla.edu/permalink/01UCS_LAL/85hnjm/alma9996685127706533)