### PR TITLE
SYS-1094: Help box for Aeon-requested materials

### DIFF
--- a/01UCS_LAL-UCLA/js/custom.js
+++ b/01UCS_LAL-UCLA/js/custom.js
@@ -691,5 +691,17 @@ app.component("prmAlmaOtherMembersAfter", {
   app.component('prmNoSearchResultAfter', {
     template: '<md-card class="default-card"><md-card-title><md-card-title-text><span class="md-headline">Where can I get research help?</span></md-card-title-text></md-card-title><md-card-content><ul><li><a href="https://www.library.ucla.edu/research-teaching-support/research-help">Ask a librarian</a></li><li><a href="https://guides.library.ucla.edu/search">Guide to using UC Library Search</a></li></ul><a href="https://library.ucla.edu" target="_blank" class="md-primoExplore-theme">UCLA Library homepage</a></md-card-content></md-card>'
   });
+
+  /* Special Collections help text box */
+  app.component('requestHintComponent', {
+    template: `<div layout="row" class="bar alert-bar zero-margin-bottom layout-align-center-center layout-row" layout-align="center center" 
+    style="background-color:transparent; border-color: var(--color-primary-blue-04); height: 45px; min-height: 45px; text-align:center">
+      <span class="bar-text margin-right-small" >For Special Collections, Film and Television Archive, and Clark Library materials, select the item's location below to display the Request link.</span></div>`
+  });
+  
+  app.component('prmRequestServicesAfter', {
+    bindings: {parentCtrl: `<`},
+    template: `<request-hint-component></request-hint-component>`    
+  });
 }());
 

--- a/01UCS_LAL-UCLA/js/custom.js
+++ b/01UCS_LAL-UCLA/js/custom.js
@@ -696,7 +696,7 @@ app.component("prmAlmaOtherMembersAfter", {
   app.component('requestHintComponent', {
     template: `<div layout="row" class="alert-bar margin-bottom-small layout-align-center-center layout-row" layout-align="center center" 
     style="background-color:transparent; border: 1px solid var(--color-primary-blue-04); border-radius: 3px; min-height: 45px; text-align:center">
-      <span class="bar-text margin-right-small" >For Special Collections, Film and Television Archive, and Clark Library materials, select the item's location below to display the Request link.</span></div>`
+      <span class="bar-text margin-right-medium" >For Special Collections, Film and Television Archive, and Clark Library materials, select the item's location below to display the Request link.</span></div>`
   });
   
   app.component('prmRequestServicesAfter', {

--- a/01UCS_LAL-UCLA/js/custom.js
+++ b/01UCS_LAL-UCLA/js/custom.js
@@ -694,8 +694,8 @@ app.component("prmAlmaOtherMembersAfter", {
 
   /* Special Collections help text box */
   app.component('requestHintComponent', {
-    template: `<div layout="row" class="bar alert-bar zero-margin-bottom layout-align-center-center layout-row" layout-align="center center" 
-    style="background-color:transparent; border-color: var(--color-primary-blue-04); height: 45px; min-height: 45px; text-align:center">
+    template: `<div layout="row" class="alert-bar margin-bottom-small layout-align-center-center layout-row" layout-align="center center" 
+    style="background-color:transparent; border: 1px solid var(--color-primary-blue-04); border-radius: 3px; min-height: 45px; text-align:center">
       <span class="bar-text margin-right-small" >For Special Collections, Film and Television Archive, and Clark Library materials, select the item's location below to display the Request link.</span></div>`
   });
   

--- a/01UCS_LAL-UCLA/js/custom.js
+++ b/01UCS_LAL-UCLA/js/custom.js
@@ -696,7 +696,7 @@ app.component("prmAlmaOtherMembersAfter", {
   app.component('requestHintComponent', {
     template: `<div layout="row" class="alert-bar margin-bottom-small layout-align-center-center layout-row" layout-align="center center" 
     style="background-color:transparent; border: 1px solid var(--color-primary-blue-04); border-radius: 3px; min-height: 45px; text-align:center">
-      <span class="bar-text margin-right-medium" >For Special Collections, Film and Television Archive, and Clark Library materials, select the item's location below to display the Request link.</span></div>`
+      <span class="bar-text margin-right-medium" >For Library Special Collections, UCLA Film and Television Archive, and Clark Library materials, select the item's location below to display the Request link.</span></div>`
   });
   
   app.component('prmRequestServicesAfter', {


### PR DESCRIPTION
Implements [SYS-1094](https://jira.library.ucla.edu/browse/SYS-1094)

Creates an additional static text box under "How to get it" on full record displays when we have a physical holdings record (not just on LSC materials). Available in a test view: [https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_1094](https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_1094)

Tested in Safari and Firefox on desktop and Chrome on mobile.

Screenshot:
<img width="739" alt="image" src="https://user-images.githubusercontent.com/7283991/214722506-cafd9d74-8aac-4352-af3a-1e8fce0262f5.png">