### PR TITLE
SYS-1153: Move scroll arrows to avoid overlap with LibChat widget on Browse pages

### DIFF
--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -428,9 +428,6 @@ md-input-container .md-input, .md-datepicker-input {
   display: none;
 } 
 
-.s-lch-widget-float-btn {
-  bottom: 1px !important;
-  right: 50px !important;
-  height: 75% !important;
-  margin-top: 12%; !important; 
+#speedDialWidget.page-nav {
+  bottom: 80px !important;
 }

--- a/01UCS_LAL-UCLA/css/custom1.css
+++ b/01UCS_LAL-UCLA/css/custom1.css
@@ -427,3 +427,10 @@ md-input-container .md-input, .md-datepicker-input {
 #searchWithinJournal.search-within-p-only {
   display: none;
 } 
+
+.s-lch-widget-float-btn {
+  bottom: 1px !important;
+  right: 50px !important;
+  height: 75% !important;
+  margin-top: 12%; !important; 
+}

--- a/01UCS_LAL-UCLA/js/custom.js
+++ b/01UCS_LAL-UCLA/js/custom.js
@@ -617,7 +617,7 @@
           var alert = $mdDialog.alert({
              title: 'Attention',
              clickOutsideToClose:true,
-             template: '<div id="libchat_secret_50402955"></div><style>.s-lch-widget-float.open { height: 55% !important;margin-top: 12% !important;}.s-lch-widget-float {bottom: 200px !important;}</style>',
+             template: '<div id="libchat_secret_50402955"></div>',
              scope: angular.extend($scope.$new(), { close: function() {$mdDialog.cancel();} })
           });
           $mdDialog.show(alert).finally(function() {
@@ -647,15 +647,6 @@
     var lc = document.createElement('script'); lc.type = 'text/javascript';
     lc.src = 'https://v2.libanswers.com/load_chat.php?hash=libanswers_secret_86530858';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.append(lc);
-    setTimeout(()=>{
-      var widget = document.getElementsByClassName("s-lch-widget-float");
-      if(widget != null){
-        widget[0].style.bottom = "1px";
-        widget[0].style.right = "50px";
-        widget[0].style.height = "75%";
-        widget[0].style.marginTop = "12%";
-      }
-    },2000);
   })();
   /*---------------libchat code ends here---------------*/
   // LibChat - END

--- a/01UCS_LAL-UCLA/js/custom.js
+++ b/01UCS_LAL-UCLA/js/custom.js
@@ -651,6 +651,7 @@
       var widget = document.getElementsByClassName("s-lch-widget-float");
       if(widget != null){
         widget[0].style.bottom = "1px";
+        widget[0].style.right = "50px";
         widget[0].style.height = "75%";
         widget[0].style.marginTop = "12%";
       }


### PR DESCRIPTION
Implements [SYS-1153](https://jira.library.ucla.edu/browse/SYS-1153)
Available in a test view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_1153

This change is intended to make Primo's Browse pages more usable by moving the previous/next page arrows up to avoid overlap with the LibChat widget. While experimenting with layout I found some redundant and unused styling for the LibChat widget within the custom.js file, so that has been cleaned up in this PR as well.

Tested on Chrome and Firefox on desktop (Mac) and mobile (Android).