### PR TITLE
SYS-1315: Fix npm install problem on Mac M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@
 # per https://github.com/ExLibrisGroup/primo-explore-devenv
 FROM node:16-bullseye
 
+# Add dependencies needed to fix problem with "npm install" of primo-explore-devenv (below) on Mac M1 ARM64,
+# which does not have pre-built node-canvas packages.
+# https://github.com/Automattic/node-canvas/wiki/Installation:-Ubuntu-and-other-Debian-based-systems
+# Note that libgif-dev, librsvg2-dev and libjpeg-dev are optional, and only required if you want gif, svg and jpeg support, respectively.
+# apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+RUN apt-get update && apt-get install -y build-essential libcairo2-dev libpango1.0-dev
+
 # Install primo-explore-devenv
 # This, and the npm install, will show lots of deprecation warnings due to the old
 # Ex Libris environment being used here.


### PR DESCRIPTION
This hopefully fixes a problem which occurs when building this Docker image on Mac M1 machines.  They need npm packages built for arm64 architecture... and `node-canvas` apparently has stopped doing that.  

The Ex Libris node environment which gets built into this Docker image doesn't explicitly require canvas, but something tries to pull it in, and the missing arm64 packages cause that `npm install` to fail.

Per [various](https://github.com/Automattic/node-canvas/issues/1733) [issues](https://github.com/Automattic/node-canvas/issues/1662), installing some extra OS-level packages may help.  This PR adds `cairo` and `pango`, which should allow `canvas` to get built from source by `npm install`.

This doesn't break anything on my end... I tried building for MacOS via Github Actions, but the `docker buildx` actions wouldn't run on that OS :( - and the GA environment apparently does not yet support M1 runners anyhow.

So, to test:
```
git pull
git checkout SYS-1315/fix_mac_canvas
docker-compose down
docker-compose build
```
Watch output carefully for errors other than the many deprecation warnings, and let me know the outcome.

