### PR TITLE
UX-1037: Remove FAQ from Primo homepage

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/html/homepage/homepage_en.html
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/html/homepage/homepage_en.html
@@ -73,7 +73,7 @@ Here you can search for books and e-books, videos/films, articles, digital media
         <md-card class="default-card">
             <md-card-title>
                 <md-card-title-text>
-                    <span class="md-headline">Borrow & Renew - Sign in to my Library Account</span>
+                    <span class="md-headline">Borrow & Renew - Sign in to My Library Account</span>
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>

--- a/views/01UCS_LAL-PRIMO_REDESIGN/html/homepage/homepage_en.html
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/html/homepage/homepage_en.html
@@ -7,7 +7,7 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-Here you can search for books and e-books, videos/films, articles, digital media, and more. UC Library Search <a href="https://ucla.libanswers.com/search/?t=0&adv=1&topics=UC%20Library%20Search">FAQ</a>
+Here you can search for books and e-books, videos/films, articles, digital media, and more.</a>
 <p></p>
 <font color="#003B5C"><b>Search Scopes</b></font>
 <style> .first-column-larger td { width :51%; } </style>
@@ -43,7 +43,8 @@ Here you can search for books and e-books, videos/films, articles, digital media
                 <ul>
                     <li><a href="https://www.library.ucla.edu/research-teaching-support/research-help">Ask a librarian</a></li>
                     <li><a href="https://guides.library.ucla.edu/search">Guide to using UC Library Search</a></li>
-                      </ul>
+                    <li><a href="https://guides.library.ucla.edu/Search/Account">Logging in to my UCLA Library Search Account</a></li>
+                </ul>
   
                       <a href="https://library.ucla.edu" target="_blank" class="md-primoExplore-theme">
                           UCLA Library homepage
@@ -72,7 +73,7 @@ Here you can search for books and e-books, videos/films, articles, digital media
         <md-card class="default-card">
             <md-card-title>
                 <md-card-title-text>
-                    <span class="md-headline">Borrow & Renew - Sign in to My Library Account</span>
+                    <span class="md-headline">Borrow & Renew - Sign in to my Library Account</span>
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>

--- a/views/01UCS_LAL-UCLA/html/homepage/homepage_en.html
+++ b/views/01UCS_LAL-UCLA/html/homepage/homepage_en.html
@@ -73,7 +73,7 @@ Here you can search for books and e-books, videos/films, articles, digital media
         <md-card class="default-card">
             <md-card-title>
                 <md-card-title-text>
-                    <span class="md-headline">Borrow & Renew - Sign in to my Library Account</span>
+                    <span class="md-headline">Borrow & Renew - Sign in to My Library Account</span>
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>

--- a/views/01UCS_LAL-UCLA/html/homepage/homepage_en.html
+++ b/views/01UCS_LAL-UCLA/html/homepage/homepage_en.html
@@ -7,7 +7,7 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-Here you can search for books and e-books, videos/films, articles, digital media, and more. UC Library Search <a href="https://ucla.libanswers.com/search/?t=0&adv=1&topics=UC%20Library%20Search">FAQ</a>
+Here you can search for books and e-books, videos/films, articles, digital media, and more.</a>
 <p></p>
 <font color="#003B5C"><b>Search Scopes</b></font>
 <style> .first-column-larger td { width :51%; } </style>
@@ -43,7 +43,8 @@ Here you can search for books and e-books, videos/films, articles, digital media
                 <ul>
                     <li><a href="https://www.library.ucla.edu/research-teaching-support/research-help">Ask a librarian</a></li>
                     <li><a href="https://guides.library.ucla.edu/search">Guide to using UC Library Search</a></li>
-                      </ul>
+                    <li><a href="https://guides.library.ucla.edu/Search/Account">Logging in to my UCLA Library Search Account</a></li>
+                </ul>
   
                       <a href="https://library.ucla.edu" target="_blank" class="md-primoExplore-theme">
                           UCLA Library homepage
@@ -72,7 +73,7 @@ Here you can search for books and e-books, videos/films, articles, digital media
         <md-card class="default-card">
             <md-card-title>
                 <md-card-title-text>
-                    <span class="md-headline">Borrow & Renew - Sign in to My Library Account</span>
+                    <span class="md-headline">Borrow & Renew - Sign in to my Library Account</span>
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>


### PR DESCRIPTION
Implements [UX-1037](https://jira.library.ucla.edu/browse/UX-1037)
Available in a test view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_UX_1037

A couple of small tweaks to the Primo homepage, as requested by Courtney and approved by DFG:
1. Remove link to Primo FAQ LibGuides (1st block)
2. Add link to Primo Account LibGuide (2nd block)

For consistency, this PR makes these changes in both the current production view and the temporary PRIMO_REDESIGN view. Changes are made only in `homepage_en.html`, which should have no effect on other parts of Primo.