### PR TITLE
ALMA-165: Add top warning bar message

### DIFF
--- a/views/01UCS_LAL-UCLA/css/custom1.css
+++ b/views/01UCS_LAL-UCLA/css/custom1.css
@@ -38,9 +38,10 @@
 }
 
 /*  Top Warning Bar Message:
-    Enable & edit manually when needed; be sure to disable afterwards.
+    Enable & edit manually when needed; be sure to disable via comment block afterwards.
     Thanks to https://www.carli.illinois.edu/products-services/i-share/discovery-interface/custom_package_topbanner
  */
+/* 
 body::before {
   content: "We're experiencing a system disruption as part of system maintenance.  Your search results may not be accurate during this time.";
   display: inline-block;
@@ -49,6 +50,7 @@ body::before {
   width: 100%;
   font-weight: bold;
 }
+*/
 /* END Top Warning Bar Message */
 
 /*Top Banner Background Color */

--- a/views/01UCS_LAL-UCLA/css/custom1.css
+++ b/views/01UCS_LAL-UCLA/css/custom1.css
@@ -37,6 +37,20 @@
   src: url("karbon-web-medium.woff") format("woff");
 }
 
+/*  Top Warning Bar Message:
+    Enable & edit manually when needed; be sure to disable afterwards.
+    Thanks to https://www.carli.illinois.edu/products-services/i-share/discovery-interface/custom_package_topbanner
+ */
+body::before {
+  content: "We're experiencing a system disruption as part of system maintenance.  Your search results may not be accurate during this time.";
+  display: inline-block;
+  background: var(--color-primary-yellow-01);
+  text-align: center;
+  width: 100%;
+  font-weight: bold;
+}
+/* END Top Warning Bar Message */
+
 /*Top Banner Background Color */
 .prm-primary-bg.prm-hue1,
 prm-spinner.prm-hue1.overlay-cover.light-on-dark:after,


### PR DESCRIPTION
Implements [ALMA-165](https://jira.library.ucla.edu/browse/ALMA-165) - but this should not be merged as-is unless the relevant banner message needs to be deployed.

[View for testing](https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_ALMA_165).

This PR adds CSS which displays a message in a warning bar at the top of every (real) page, like the home page, search results, and account pages.  It does *not* directly appear on Primo's "overlay" pages, like the detailed record display and the "more ..." page, though it may be seen in the background beneath those overlays.

Since there's no obvious way to toggle this on & off without changing the code directly, this PR should not be merged as-is unless the re-indexing causes disruption.  Though since merging & deployment are disconnected, I guess it doesn't matter, but we should decide how to handle this long-term.

