### PR TITLE
SYS-1325: Basic restyling of Search History list

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/account.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/account.css
@@ -49,3 +49,21 @@ md-ink-bar {
 prm-loan .overdue-line {
   color: var(--status-error-02);
 }
+
+/* Search history */
+prm-saved-queries-list md-list-item {
+  border: 2px solid var(--color-primary-blue-01);
+  border-radius: 4px;
+}
+
+/* Titles: U/Max/Heading/Step 1 */
+md-list-item a.bold-text h3 {
+  color: var(--color-black);
+  font-size: 26px !important;
+}
+
+/* Other search history info: U/Body/Paragraph */
+md-list-item p.text-headings {
+  color: var(--color-black);
+  font-size: 20px !important;
+}

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/custom1.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/custom1.css
@@ -83,6 +83,12 @@ span.best-location-library-code.locations-link {
 span[translate="nui.request.request"] {
   display: none;
 }
+
+/* Body of most (all?) pages should be white */
+body {
+  background-color: var(--color-white);
+}
+
 /*match UCSC font*/
 body .header {
   font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Implements [SYS-1325](https://jira.library.ucla.edu/browse/SYS-1325).

This PR adds basic styling for the Search History page.
* White background (set via `body` in `custom1.css`)
* Black text (this and the below via `account.css`)
* Font sizes specified in Figma design for Loans -> Items (since no Figma design for the Search History page)
* Card borders, also as specified for Loans -> Items

Since Figma references "groups" like `U/Max/Heading/Step 1`, which we can't easily define in this regular CSS, I added these references as comments above relevant entries.  I also used `!important` when required to override inherited styling which conflicts with the Figma design for font size.

I did not attempt to style the pseudo-tab headings like "SEARCH HISTORY" and "SAVED RECORDS", as these are more complex and will be addressed... somewhere else :)

### Testing:
* Pull and switch to branch `SYS-1325/search_history_style`
* Make sure `vars.env` has `VIEW=01UCS_LAL-PRIMO_REDESIGN`
* Do at least one search, then visit
http://localhost:8003/discovery/favorites?vid=01UCS_LAL:UCLA&lang=en&section=search_history

Results should look similar to 
![primo_search_history_styling](https://github.com/UCLALibrary/primo_ve/assets/2213836/7ce83b73-646f-4c0f-a1ce-d61a263471f8)
