### PR TITLE
SYS-1326: Basic restyling of Saved Searches list

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/account.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/account.css
@@ -50,19 +50,19 @@ prm-loan .overdue-line {
   color: var(--status-error-02);
 }
 
-/* Search history */
+/* Search History and Saved Searches: Item Boxes */
 prm-saved-queries-list md-list-item {
   border: 2px solid var(--color-primary-blue-01);
   border-radius: 4px;
 }
 
-/* Titles: U/Max/Heading/Step 1 */
+/* Search History and Saved Searches: Titles: U/Max/Heading/Step 1 */
 md-list-item a.bold-text h3 {
   color: var(--color-black);
   font-size: 26px !important;
 }
 
-/* Other search history info: U/Body/Paragraph */
+/* Search History and Saved Searches: Other info: U/Body/Paragraph */
 md-list-item p.text-headings {
   color: var(--color-black);
   font-size: 20px !important;


### PR DESCRIPTION
Implements [SYS-1326](https://jira.library.ucla.edu/browse/SYS-1326).

There are no actual code changes here, since the few elements being updated use the exact same selectors as on the closely-related Search History page (#31).

I did update the comments in `account.css` to show that the previous changes now apply to both pages.

Testing:
Switch to branch `SYS-1326/saved_searches`, log in using the test user `P0002829610`, confirm saved searches look the same as entries on the Search History page (do a search if needed, to populate that page).

Screen shot:
![primo_saved_searches_styling](https://github.com/UCLALibrary/primo_ve/assets/2213836/7406c1eb-dcdd-4bc7-839a-cec1a66d7f2e)
