### PR TITLE
SYS-1327: Update colors and fonts for saved records

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -210,3 +210,35 @@ span.facet-counter {
   line-height: 160%;
   letter-spacing: 0.2px;
 }
+
+/* Search Results: "Sort By": U/Body/Button */
+h3.section-title-header {
+  color: var(--color-primary-blue-05);
+  /* Fall back to generic sans-serif until Proxima Nova issue is resolved */
+  font-family: Proxima Nova, sans-serif;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 120%;
+}
+
+/* Saved Records: Most styles from Search Results apply automatically;
+*  the following are exceptions / differences.
+*/
+
+/* Saved Records: change background to white, which isn't happening via <body> */
+prm-favorites div.layout-row {
+  background-color: var(--color-white);
+}
+
+/* Saved Records: Labels, treated same as Facet Titles: U/Body/Paragraph */
+div.md-chip-content {
+  /* Design has this as #000, looks the same to me... */
+  color: var(--color-black);
+  font-family: Karbon;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 160%;
+  letter-spacing: 0.2px;
+}


### PR DESCRIPTION
Implements [SYS-1327](https://uclalibrary.atlassian.net/browse/SYS-1327).

This PR adds color and font styling for a few elements of the Saved Records page which differ from the Search Results page.  Most elements have the same selectors on these two pages.  The differences currently handled are:
* Background color: different selector; kept these separate for now
* Facets: only on Search Results, not relevant for Saved Records
* Labels: similar to Facets, but not identical
  * Labels applied to a record display below its Availability

Known problems:
* The Figma design does not cover this page, so I only attempted to change elements which were similar to ones already styled via Search Results.
* Elements not yet styled on Search Results, like the Facet/Labeling coloring & layout, pagination, and the page-specific toolbar, are not styled on Saved Records either.

Testing:
Log in as the test user `P0002829610`, then go to the [Saved Records page](http://localhost:8003/discovery/favorites?vid=01UCS_LAL:UCLA&section=items).


[SYS-1327]: https://uclalibrary.atlassian.net/browse/SYS-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ