### PR TITLE
SYS-1317: Item detail styling

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/custom1.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/custom1.css
@@ -3,3 +3,5 @@
 @import "ucla/account.css";
 @import "ucla/item.css";
 @import "ucla/search.css";
+/* typekit link to use Proxima Nova (Adobe font) */
+@import url("https://use.typekit.net/xso3wzv.css");

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/custom1.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/custom1.css
@@ -36,6 +36,7 @@
   --color-visit-fushia-03: #ff94db;
   --color-about-purple-03: #c099ff;
   --status-error-02: #b3070d;
+  --status-success-02: #00661b;
 }
 
 @font-face {

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/item.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/item.css
@@ -98,3 +98,29 @@ div.full-view-section {
 .full-view-section {
   padding-left: 4em;
 }
+
+/* redesign colors and fonts */
+prm-full-view .full-view-inner-container,
+.full-view-spacer,
+prm-full-view-cont md-content {
+  background-color: var(--color-white) !important;
+}
+
+.availability-status.available_in_library {
+  color: var(--status-success-02);
+}
+
+/* metadata labels */
+#item-details .bold-text {
+  font-family: "Karbon";
+  font-weight: 700;
+  font-size: 16px;
+  text-transform: uppercase;
+}
+
+.full-view-section .section-title {
+  font-family: "Karbon";
+  font-weight: 600;
+  line-height: 100%;
+  font-size: 36px;
+}

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/item.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/item.css
@@ -121,10 +121,26 @@ primo-explore #full-view-container {
 }
 
 /* metadata values: U/Body/Caption */
-
 .full-view-section .section-title {
   font-family: "Karbon";
   font-weight: 600;
   line-height: 100%;
   font-size: 36px;
+}
+
+/* Main title: U/Max/Heading/Step1 */
+prm-brief-result .item-title span {
+  color: var(--color-black);
+  font-family: Karbon;
+  font-size: 26px;
+  font-weight: 700;
+}
+
+/* Item sidebar links: /* U/Body/Link */
+.services-index-under button {
+  font-family: "Proxima Nova", "sans-serif";
+  font-size: 20px;
+  font-weight: 400;
+  text-transform: none;
+  color: var(--color-primary-blue-04) !important;
 }

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/item.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/item.css
@@ -100,9 +100,11 @@ div.full-view-section {
 }
 
 /* redesign colors and fonts */
+
+/* background color = white */
 prm-full-view .full-view-inner-container,
-.full-view-spacer,
-prm-full-view-cont md-content {
+prm-full-view-cont md-content,
+primo-explore #full-view-container {
   background-color: var(--color-white) !important;
 }
 
@@ -110,13 +112,15 @@ prm-full-view-cont md-content {
   color: var(--status-success-02);
 }
 
-/* metadata labels */
+/* metadata labels: U/Body/Overline */
 #item-details .bold-text {
   font-family: "Karbon";
   font-weight: 700;
   font-size: 16px;
   text-transform: uppercase;
 }
+
+/* metadata values: U/Body/Caption */
 
 .full-view-section .section-title {
   font-family: "Karbon";

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/item.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/item.css
@@ -104,43 +104,133 @@ div.full-view-section {
 /* background color = white */
 prm-full-view .full-view-inner-container,
 prm-full-view-cont md-content,
-primo-explore #full-view-container {
+primo-explore #full-view-container,
+prm-full-view-cont .padded-container {
   background-color: var(--color-white) !important;
 }
 
-.availability-status.available_in_library {
-  color: var(--status-success-02);
+/* Back to search results: U/Body/Link */
+prm-full-view-cont .back-button {
+  font-family: proxima-nova;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 120%;
+  text-transform: none;
+  color: var(--color-primary-blue-04);
 }
 
-/* metadata labels: U/Body/Overline */
-#item-details .bold-text {
-  font-family: "Karbon";
-  font-weight: 700;
-  font-size: 16px;
+/* availability status: U/Body/Overline */
+prm-full-view span.availability-status {
+  font-family: Karbon;
+  font-size: 16px !important;
+  font-weight: 700 !important;
+  line-height: 160%;
+  letter-spacing: 1.6px !important;
   text-transform: uppercase;
 }
 
-/* metadata values: U/Body/Caption */
+/* Metadata labels in Details section: U/Body/Overline */
+#item-details .bold-text {
+  font-family: Karbon;
+  font-weight: 700 !important;
+  font-size: 16px;
+  text-transform: uppercase;
+  line-height: 160%;
+  letter-spacing: 1.6px;
+  color: var(--color-black);
+}
+
+/* Metadata values in Details section: U/Body/Caption */
+#item-details {
+  font-family: proxima-nova;
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--color-black);
+  line-height: 160%;
+  letter-spacing: 0.16px;
+}
+
+/* Links within metadata values */
+#item-details a {
+  color: var(--color-primary-blue-04);
+}
+
+/* Section headers (e.g. Details): U/Min/Heading/Step5 */
 .full-view-section .section-title {
-  font-family: "Karbon";
+  font-family: Karbon;
   font-weight: 600;
-  line-height: 100%;
   font-size: 36px;
+  line-height: 120%;
+  color: var(--color-primary-blue-05);
 }
 
 /* Main title: U/Max/Heading/Step1 */
-prm-brief-result .item-title span {
+prm-full-view .item-title span {
   color: var(--color-black);
   font-family: Karbon;
   font-size: 26px;
   font-weight: 700;
+  line-height: 120%;
 }
 
 /* Item sidebar links: /* U/Body/Link */
 .services-index-under button {
-  font-family: "Proxima Nova", "sans-serif";
+  font-family: proxima-nova;
   font-size: 20px;
   font-weight: 400;
   text-transform: none;
+  line-height: 120%;
   color: var(--color-primary-blue-04) !important;
+}
+
+/* Item content type (e.g. Journal, Book): U/Body/Caption,
+with additional background box */
+prm-full-view .media-content-type span {
+  font-family: proxima-nova;
+  font-size: 16px;
+  text-transform: none;
+  font-weight: 400;
+  color: var(--secondary-grey-05);
+  border-radius: 5px;
+  background: var(--color-primary-blue-01);
+  padding: 4px 43px;
+}
+
+/* Links in Links section: no style name given */
+prm-service-links {
+  font-family: proxima-nova;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 100%;
+  color: var(--color-primary-blue-03);
+}
+
+/* Sign in to request banner: U/Body/Paragraph */
+prm-request-services prm-alert-bar {
+  font-family: Karbon;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 160%;
+  letter-spacing: 0.2px;
+  border: 1.5px solid var(--color-primary-blue-02);
+  border-radius: 0px;
+}
+prm-request-services prm-alert-bar .bar {
+  background: var(--color-white) !important;
+  border: none;
+}
+
+/* Sign in button on banner: U/Body/Button */
+prm-request-services prm-alert-bar prm-authentication button {
+  background: var(--color-primary-blue-03) !important;
+  color: var(--color-white) !important;
+  font-family: proxima-nova !important;
+  font-size: 18px !important;
+  font-weight: 400 !important;
+  line-height: 120% !important;
+}
+
+/* "Location Items" section ("Requests" in mockup) */
+prm-location-items {
+  background: var(--color-primary-blue-01);
 }

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -85,7 +85,7 @@ span [data-field-selector] {
   overflow: hidden;
   text-overflow: ellipsis;
   /* Fall back to generic sans-serif until Proxima Nova issue is resolved */
-  font-family: Proxima Nova, sans-serif;
+  font-family: proxima-nova, sans-serif;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;


### PR DESCRIPTION
Implements [SYS-1317](https://uclalibrary.atlassian.net/browse/SYS-1317)

A first step toward styling item detail pages.
This PR also includes an update to `custom1.css` to allow use of Proxima Nova, and a small change to `search.css` to use this font (syntax: `font-family: proxima-nova;`).

On the item detail pages, the following areas are updated to align with the Figma mockups:
* Title, publication metadata, availability status, and item type (e.g. Book) at top of page
* Section headings
* Metadata values and labels in Links and Details sections
* "Please sign in to check if there are any request options" banner and button
* Sidebar links
* Back to results button
* Background colors (should be white everywhere)

The following are NOT included in this PR and will be done in a later ticket:
* Location display
* Item display
* Digital item links
* Request links
* Layout and alignment fixes

Testing: please look at a few items of different formats as both standalone detail pages and in the modal/popup view accessed from search results. You will need to be signed out to see the sign in banner.

[SYS-1317]: https://uclalibrary.atlassian.net/browse/SYS-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ