### PR TITLE
SYS-1330: Update colors and fonts for Journal Title Search page

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -299,3 +299,46 @@ md-input-container.md-input-has-placeholder input[placeholder] {
   line-height: 160%;
   letter-spacing: 0.16px;
 }
+
+/* Journal Search: Label before search box: No design */
+prm-atoz-search-bar .classic-input .search-scope {
+  background-color: var(--color-white);
+}
+
+/* Journal Search: Label before search box: text seems to need to target the span */
+span[translate="nui.journalsearch.title"] {
+  color: var(--color-black);
+  font-family: proxima-nova;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 160%;
+  letter-spacing: 0.16px;
+}
+
+/* Journal Search: Category sidebar: No design */
+div.databases-categories,
+div.sticking-wrapper {
+  background-color: var(--color-white);
+}
+
+/* Journal Search: Category heading: U/Min/Heading/Step4 */
+h2[translate="nui.journalsearch.category.title"] {
+  color: var(--color-primary-blue-05);
+  font-family: Karbon;
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 120%;
+}
+
+/* Journal Search: Categories and sub-categories: U/Body/Paragraph */
+prm-tree-nav md-list-item p {
+  color: var(--color-black);
+  font-family: Karbon;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 160%;
+  letter-spacing: 0.2px;
+}


### PR DESCRIPTION
Implements [SYS-1330](https://uclalibrary.atlassian.net/browse/SYS-1330).

This PR updates the colors and fonts on the Journal Title Search page.  I did not find a design for this, so based the changes on similar elements from the Advanced Search page and the Search Results page.

I did not attempt to style the search button (similar to others on the Advanced Search page), or the grey boxes/cards of text.  Those may get done with similar elements on the Home Page, or may need to wait for UX assistance.

Testing: Go to the [Journal Title Search page](http://localhost:8003/discovery/jsearch?vid=01UCS_LAL:UCLA).  Compare "Journals by Category" styling to the facets which appear after a search.  Other than some clipping on the facets, they should be the same.

[SYS-1330]: https://uclalibrary.atlassian.net/browse/SYS-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ