### PR TITLE
SYS-1331: Update colors and fonts for Browse Search page

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -316,6 +316,20 @@ span[translate="nui.journalsearch.title"] {
   letter-spacing: 0.16px;
 }
 
+/* Journal Search: Title or ISSN placeholder text: No design,
+   match Advanced Search placeholder: U/Body/Caption
+*/
+md-autocomplete[md-input-id="searchBarJournal"] {
+  /* Not found in design tokens */
+  color: var(--library-palette-child-brand-digital-charcoal, #434343);
+  font-family: proxima-nova;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 160%;
+  letter-spacing: 0.16px;
+}
+
 /* Journal Search: Category sidebar: No design */
 div.databases-categories,
 div.sticking-wrapper {
@@ -341,4 +355,21 @@ prm-tree-nav md-list-item p {
   font-weight: 600;
   line-height: 160%;
   letter-spacing: 0.2px;
+}
+
+/* Browse Search: Label before search box: No design */
+prm-browse-search-bar .classic-input .search-scope {
+  background-color: var(--color-white);
+}
+
+/* Browse Search: Hide "Browse by" label, which seems out of place and
+   has hard-coded "bold-text" class */
+prm-browse-search-bar label[translate="nui.browse.browseby"] {
+  display: none;
+}
+
+/* Browse Search: change background to white, which isn't happening via <body> */
+/* This does not change the results list, which is grey / white when hovered. */
+prm-browse-search md-content {
+  background-color: var(--color-white) !important;
 }


### PR DESCRIPTION
(Mostly) implements [SYS-1331](https://uclalibrary.atlassian.net/browse/SYS-1331).

This PR updates colors and fonts used on the Browse Search page.  It also fixes a font problem with placeholder text for the Journal Search page, overlooked in #38.

I hid the "Browse by" label, which seems to be hard-coded with a bold style, as it looked out of place otherwise.

It does not change the grey color which displays for browse results (which changes to white when mouse hovers over a single result).  It also does not change the font used for browse results.  I found no design for this page, and this aspect will probably need help from the UX team.

Testing: Go to the [Browse Search page](http://localhost:8003/discovery/browse?vid=01UCS_LAL:UCLA), enter a search, etc.


[SYS-1331]: https://uclalibrary.atlassian.net/browse/SYS-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ