### PR TITLE
SYS-1328: Improve home page nav bar / menu colors and fonts

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
@@ -60,8 +60,9 @@ div.top-nav-bar {
   color: var(--color-black) !important;
 }
 
-/* Top Banner: Menu item text: U/Body/Overline */
-div[data-main-menu-item] a.button-over-dark span.item-content {
+/* Top Banner: Menu item text and "more links (...)": U/Body/Overline */
+div[data-main-menu-item] a.button-over-dark span.item-content,
+button#more-links-button span.item-content {
   color: var(--color-black);
   text-align: center;
   font-family: Karbon;

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
@@ -73,12 +73,13 @@ div[data-main-menu-item] a.button-over-dark span.item-content {
   text-transform: uppercase;
 }
 
-/* Top Banner: My Library Account and Menu: U/Body/Link */
+/* Top Banner: My Library Account, and Menu (heading and options): U/Body/Link */
 /* TODO: Change Alma config, currently MY LIBRARY ACCOUNT, to My Library Account;
     otherwise, javascript may be needed since CSS can't do Sentence Case.
 */
 button.sign-in-btn-ctm,
-button.button-with-menu-arrow {
+button.button-with-menu-arrow,
+md-menu-item .md-button {
   color: var(--color-black) !important;
   text-align: center;
   font-family: proxima-nova;

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
@@ -44,12 +44,55 @@
   src: url("karbon-web-medium.woff") format("woff");
 }
 
-/*Top Banner Background Color */
+/* Top Banner Background Color */
 .prm-primary-bg.prm-hue1,
 prm-spinner.prm-hue1.overlay-cover.light-on-dark:after,
 prm-topbar .top-nav-bar,
 prm-search-bar.prm-hue1 {
   background-color: var(--color-white);
+}
+
+/* Top Banner: Menu item box */
+div.top-nav-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  color: var(--color-black) !important;
+}
+
+/* Top Banner: Menu item text: U/Body/Overline */
+div[data-main-menu-item] a.button-over-dark span.item-content {
+  color: var(--color-black);
+  text-align: center;
+  font-family: Karbon;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 160%;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+}
+
+/* Top Banner: My Library Account and Menu: U/Body/Link */
+/* TODO: Change Alma config, currently MY LIBRARY ACCOUNT, to My Library Account;
+    otherwise, javascript may be needed since CSS can't do Sentence Case.
+*/
+button.sign-in-btn-ctm,
+button.button-with-menu-arrow {
+  color: var(--color-black) !important;
+  text-align: center;
+  font-family: proxima-nova;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 120%;
+}
+
+/* Top Banner: QR and Favorites icons */
+/* Doesn't match design, problems with hover, but at least they're visible... */
+prm-search-bookmark-filter md-icon svg {
+  color: var(--color-black) !important;
+  fill: var(--color-black);
 }
 
 /*!!!!!!!  TOPBAR - USER AREA - HOVER COLOR !!!!!!!!*/

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -243,6 +243,18 @@ div.md-chip-content {
 /* Advanced Search
 */
 
+/* Search bar: Advanced Search: U/Body/Button */
+/* TODO: Should be outlined box instead of color change on hover */
+button.switch-to-advanced {
+  color: var(--color-white);
+  font-family: proxima-nova;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 120%;
+  text-transform: capitalize;
+}
+
 /* Advanced Search: change background to white, which isn't happening via <body> */
 div.advanced-search-backdrop,
 div.advanced-search-output md-card {


### PR DESCRIPTION
(Mostly) implements [SYS-1328[(https://uclalibrary.atlassian.net/browse/SYS-1328).

This PR implements the color and font changes for the home page, as much as practical for now.
* Top nav bar colors and fonts match the design (assuming no hover transitions are intended)
* SVG icons for QR and Favorites are visible, though they do not match the design.
* "My Library Account" font is correct, but forcing hard-coded UPPERCASE "MY LIBRARY ACCOUNT" to Sentence Case is not possible via CSS.  This will require a label change in Alma (`eshelf.signin.title`?), or possibly javascript.
* Styling of text content of home page itself was not attempted.
* "ADVANCED SEARCH" link/button next to search bar was restyled (color/font only, not hover transition) via `search.css`.
