### PR TITLE
SYS-1366: Revise display of Special Collections request help message

### DIFF
--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -687,8 +687,8 @@ app.component("prmAlmaOtherMembersAfter", {
   /* Special Collections help text box */
   app.component('requestHintComponent', {
     template: `<div layout="row" class="alert-bar margin-bottom-small layout-align-center-center layout-row" layout-align="center center" 
-    style="background-color: var(--color-primary-blue-02); border: 1px solid var(--color-primary-blue-04); border-radius: 3px; min-height: 45px; text-align:center">
-      <span class="bar-text margin-right-medium" >For Library Special Collections, UCLA Film and Television Archive, and Clark Library materials, select the item's location below to display the Request link.</span></div>`
+    style="text-align:center">
+      <span class="bar-text margin-right-medium">For Special Collections, Film & TV Archive, and Clark Library, select the location below to display the Request link.</span></div>`
   });
   
   app.component('prmRequestServicesAfter', {


### PR DESCRIPTION
Implements [SYS-1366](https://uclalibrary.atlassian.net/browse/SYS-1366)

This PR changes the blue box currently visible on items with physical holdings to a minimally-styled message that should fit in a single line for desktop display. Available in a test view: https://ucla.primo.exlibrisgroup.com/permalink/01UCS_LAL/1n8raj8/alma9916594223606533 

[SYS-1366]: https://uclalibrary.atlassian.net/browse/SYS-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ