### PR TITLE
SYS-1362: Add Ethical Description statement to Primo

### DIFF
--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -695,5 +695,21 @@ app.component("prmAlmaOtherMembersAfter", {
     bindings: {parentCtrl: `<`},
     template: `<request-hint-component></request-hint-component>`    
   });
+
+  /* Ethical Description Note */
+  app.component('ethicalDescriptionNote', {
+    template: `<div layout="row" class="alert-bar layout-align-center-center layout-row" layout-align="center center" 
+    style="border: 2px solid var(--color-primary-blue-04); border-radius: 3px; text-align:left; padding:4px;">
+      <span class="bar-text">We are committed to updating our catalog records and finding aids whenever feasible 
+      to revise problematic descriptions and subjects, including the addition of relevant context.
+      <b>To report harmful language, please use 
+      <a href="https://ucla.libwizard.com/id/38f45c482a5fcb0b715a7e9e3ddee8b2" target="_blank" rel="noopener noreferrer">this form</a>.</b> 
+      </span></div>`
+  });
+
+  app.component('prmServiceDetailsAfter', {
+    bindings: {parentCtrl: `<`},
+    template: `<ethical-description-note></ethical-description-note>`    
+  });
 }());
 


### PR DESCRIPTION
Implements [SYS-1362](https://uclalibrary.atlassian.net/browse/SYS-1362)
Available in a test view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_1362

This PR adds a message to the bottom of the Details section of every Primo record page. The text and format have been approved by DFG and the Ethical Description subteam. The message includes a link to a form, which should open in a new tab.

[SYS-1362]: https://uclalibrary.atlassian.net/browse/SYS-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ