### PR TITLE
SYS-1457: Add Ethical Description note in Primo Redesign view

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/item.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/item.css
@@ -296,7 +296,8 @@ prm-location-items md-list-item {
 }
 
 /* Ethical Description note: U/Body/Caption */
-ethical-description-note div {
+ethical-description-note #ed-box {
+  color: var(--color-black);
   font-family: proxima-nova;
   font-size: 16px;
   font-weight: 400;
@@ -304,8 +305,14 @@ ethical-description-note div {
   letter-spacing: 0.16px;
   text-align: center;
   border: 1.5px solid var(--color-primary-blue-02);
-  padding: 4px;
 }
-ethical-description-note div a {
+
+ethical-description-note #ed-text {
+  display: inline-block;
+  text-align: left;
+  max-width: 80%;
+}
+
+ethical-description-note #ed-text a {
   color: var(--color-primary-blue-04);
 }

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/item.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/item.css
@@ -294,3 +294,18 @@ prm-location-items md-list-item {
   letter-spacing: 0.16px !important;
   font-weight: normal !important;
 }
+
+/* Ethical Description note: U/Body/Caption */
+ethical-description-note div {
+  font-family: proxima-nova;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 160%;
+  letter-spacing: 0.16px;
+  text-align: center;
+  border: 1.5px solid var(--color-primary-blue-02);
+  padding: 4px;
+}
+ethical-description-note div a {
+  color: var(--color-primary-blue-04);
+}

--- a/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
@@ -695,5 +695,19 @@ app.component("prmAlmaOtherMembersAfter", {
     bindings: {parentCtrl: `<`},
     template: `<request-hint-component></request-hint-component>`    
   });
+  /* Ethical Description Note */
+  app.component('ethicalDescriptionNote', {
+    template: `<div layout="row" class="alert-bar layout-align-center-center layout-row" layout-align="center center">
+      <span class="bar-text">We are committed to updating our catalog records and finding aids whenever feasible 
+      to revise problematic descriptions and subjects, including the addition of relevant context.
+      <b>To report harmful language, please use 
+      <a href="https://ucla.libwizard.com/id/38f45c482a5fcb0b715a7e9e3ddee8b2" target="_blank" rel="noopener noreferrer">this form</a>.</b> 
+      </span></div>`
+  });
+
+  app.component('prmServiceDetailsAfter', {
+    bindings: {parentCtrl: `<`},
+    template: `<ethical-description-note></ethical-description-note>`    
+  });
 }());
 

--- a/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
@@ -697,12 +697,12 @@ app.component("prmAlmaOtherMembersAfter", {
   });
   /* Ethical Description Note */
   app.component('ethicalDescriptionNote', {
-    template: `<div layout="row" class="alert-bar layout-align-center-center layout-row" layout-align="center center">
-      <span class="bar-text">We are committed to updating our catalog records and finding aids whenever feasible 
+    template: `<div id="ed-box">
+      <div id="ed-text">We are committed to updating our catalog records and finding aids whenever feasible 
       to revise problematic descriptions and subjects, including the addition of relevant context.
       <b>To report harmful language, please use 
       <a href="https://ucla.libwizard.com/id/38f45c482a5fcb0b715a7e9e3ddee8b2" target="_blank" rel="noopener noreferrer">this form</a>.</b> 
-      </span></div>`
+      </div></div>`
   });
 
   app.component('prmServiceDetailsAfter', {


### PR DESCRIPTION
Implements [SYS-1457](https://uclalibrary.atlassian.net/browse/SYS-1457)
Available in the redesign view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:PRIMO_REDESIGN

Related to [SYS-1362](https://uclalibrary.atlassian.net/browse/SYS-1362), this PR adds the Ethical description note to the Primo redesign view, styled to match the design changes. Since this was not part of the Figma designs, I've taken the styling of the "Please sign in to check if there are any request options" box: a light blue border with centered text. The text styling of the new message should match the metadata values above it. I also moved the CSS from inline to the item.css file.

[SYS-1457]: https://uclalibrary.atlassian.net/browse/SYS-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1362]: https://uclalibrary.atlassian.net/browse/SYS-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ