### PR TITLE
SYS-1468: new Advanced Search styling

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -338,7 +338,7 @@ prm-advanced-search .layout-xs-column {
 .md-button.md-primary,
 .md-button.button-notice:focus,
 .md-button.button-notice:hover,
-.md-button.button-confirm,
+.md-button.button-confirm.button-large,
 .switch-to-simple {
   color: var(--color-white) !important;
   background-color: var(--color-primary-blue-03) !important;

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -170,12 +170,13 @@ h2.sidebar-title {
   font-family: Karbon;
   font-size: 40px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: 400;
   line-height: 120%;
 }
 
 /* Search Results: Facet header: U/Min/Heading/Step4 */
-span.section-title-header {
+span.section-title-header,
+button.section-title {
   color: var(--color-primary-blue-05);
   font-family: Karbon;
   font-size: 32px;
@@ -192,7 +193,7 @@ div.expand-section-button {
   font-family: Karbon;
   font-size: 20px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: 400;
   line-height: 160%;
   letter-spacing: 0.2px;
 }
@@ -279,13 +280,20 @@ legend[translate="nui.search-advanced.searchFilters"],
 md-input-container.md-input-has-value {
   color: var(--color-black);
   font-family: Karbon;
-  font-size: 20px;
   font-style: normal;
   font-weight: 400 !important;
   line-height: 160%;
   letter-spacing: 0.2px;
   /* Override scaling from prm-advanced-search legend */
   transform: scale(1);
+}
+legend[translate="nui.search-advanced.searchFilters"],
+#advancedSearchMaterialType,
+#searchFieldsGroupAdvancedSearch,
+#advancedSearchLanguage,
+#dayStartListBox,
+#dayEndListBox {
+  font-size: 20px;
 }
 
 /* Advanced Search: Scopes, Search filters (values) : U/Body/Caption */
@@ -310,6 +318,87 @@ md-input-container.md-input-has-placeholder input[placeholder] {
   font-weight: 400;
   line-height: 160%;
   letter-spacing: 0.16px;
+}
+
+/* Advanced search: background color */
+.advanced-search-backdrop {
+  background-color: var(--color-secondary-grey-01) !important;
+}
+prm-advanced-search .layout-xs-column {
+  background-color: var(--color-white) !important;
+}
+
+/* Advanced search box: remove drop shadow and recolor border */
+.form-focus {
+  box-shadow: initial;
+  border-color: var(--color-secondary-grey-02);
+}
+
+/* Advanced search buttons */
+.md-button.md-primary,
+.md-button.button-notice:focus,
+.md-button.button-notice:hover,
+.md-button.button-confirm,
+.switch-to-simple {
+  color: var(--color-white) !important;
+  background-color: var(--color-primary-blue-03) !important;
+  font-family: proxima-nova;
+  padding: 11px 24px !important;
+  font-size: 18px;
+  line-height: 120%;
+  text-transform: none;
+  border: 1.5px solid var(--color-primary-blue-03) !important;
+}
+.md-button.md-primary:focus,
+.md-button.md-primary:hover,
+.md-button.button-notice,
+.md-button.button-confirm:focus,
+.md-button.button-confirm:hover {
+  color: var(--color-black) !important;
+  background-color: var(--color-white) !important;
+  border: 1.5px solid var(--color-primary-blue-02) !important;
+  font-family: proxima-nova;
+  padding: 11px 24px !important;
+  font-size: 18px;
+  line-height: 120%;
+  text-transform: none;
+}
+
+/* Advanced search: radio buttons */
+md-radio-button.md-checked .md-on {
+  background-color: var(--color-default-cyan-03);
+}
+md-radio-button .md-off {
+  border-color: var(--color-default-cyan-03) !important;
+}
+
+/* Advanced search: underline "Search Criteria" in correct color */
+md-ink-bar {
+  background-color: var(--color-default-cyan-03) !important;
+}
+/* Advanced search: text color for "Search Criteria" */
+md-tabs
+  md-tabs-wrapper
+  md-tabs-canvas
+  md-pagination-wrapper
+  md-tab-item.md-active:not([disabled]) {
+  color: var(--color-black) !important;
+}
+
+/* Advanced search: align right-side filters with left */
+.advanced-drop-downs.zero-margin {
+  margin-top: 13px !important;
+  max-width: 40%;
+}
+.advanced-drop-downs md-input-container md-select {
+  padding-bottom: 8px !important;
+}
+.advanced-drop-downs .date-range-inputs {
+  margin-bottom: -12px !important;
+}
+/* Advanced search: add underlines to terms in search summary at bottom */
+.advanced-search-output .input-complex-rows.ng-not-empty {
+  border-bottom: 2px solid var(--color-default-cyan-03);
 }
 
 /* Journal Search: Label before search box: No design */
@@ -384,4 +473,18 @@ prm-browse-search-bar label[translate="nui.browse.browseby"] {
 /* This does not change the results list, which is grey / white when hovered. */
 prm-browse-search md-content {
   background-color: var(--color-white) !important;
+}
+
+/* Facets sidebar width */
+.primo-scrollbar {
+  width: 474px;
+}
+#facets {
+  max-width: 474px;
+}
+
+/* Facets sidebar: make brackets surrounding counts italic */
+.sidebar-section .text-in-brackets::before,
+.sidebar-section .text-in-brackets::after {
+  font-style: italic;
 }

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -334,7 +334,7 @@ prm-advanced-search .layout-xs-column {
   border-color: var(--color-secondary-grey-02);
 }
 
-/* Advanced search buttons */
+/*Advanced search buttons */
 .md-button.md-primary,
 .md-button.button-notice:focus,
 .md-button.button-notice:hover,
@@ -348,6 +348,14 @@ prm-advanced-search .layout-xs-column {
   line-height: 120%;
   text-transform: none;
   border: 1.5px solid var(--color-primary-blue-03) !important;
+}
+/*mobile breakpoint for buttons: simpler x style for Simple Search */
+@media (max-width: 599px) {
+  .switch-to-simple {
+    padding: 8px !important;
+    border: none !important;
+    font-size: 14px !important;
+  }
 }
 .md-button.md-primary:focus,
 .md-button.md-primary:hover,
@@ -390,6 +398,13 @@ md-tabs
   margin-top: 13px !important;
   max-width: 40%;
 }
+/* breakpoint for mobile */
+@media (max-width: 599px) {
+  .advanced-drop-downs.zero-margin {
+    max-width: 100%;
+  }
+}
+
 .advanced-drop-downs md-input-container md-select {
   padding-bottom: 8px !important;
 }


### PR DESCRIPTION
Implements [SYS-1468](https://uclalibrary.atlassian.net/browse/SYS-1468)

This PR adds styling to the redesigned Advanced Search to better match the rest of Primo. This styling was determined in pairing sessions with Axa and Taylor and is simpler than that specified in the Figma designs. Except as noted below (font sizes and sidebar changes), these changes should only affect the Advanced Search display.

This styling should work and look reasonable across a variety of screen sizes. In a couple of places, a breakpoint at 599px (ExLibris's "xs" size) is used to style elements differently on small screens.

This PR also includes some unrelated fixes made during the pairing sessions. These include several font size fixes (changes in lines 297 and before) and fixes to the width and display of parentheses in the search sidebar (lines 492-505). 

One desired change not included in the PR is to the animated dark blue underline that appears when a text input is focused (under the text "example" in the screenshot). Ideally this should use `--color-default-cyan-03`. Any ideas on how to achieve this would be appreciated, but it's not a high-impact change.

Screenshot of intended display:
<img width="1093" alt="image" src="https://github.com/UCLALibrary/primo_ve/assets/7283991/fa1012c0-a94e-4bb2-9a7f-8304683ec0b1">


[SYS-1468]: https://uclalibrary.atlassian.net/browse/SYS-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ