### PR TITLE
SYS-1467: Add search results footers

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/main.css
@@ -37,6 +37,7 @@
   --color-about-purple-03: #c099ff;
   --status-error-02: #b3070d;
   --status-success-02: #00661b;
+  --rounded-slightly-all: 4px;
 }
 
 @font-face {
@@ -289,4 +290,93 @@ md-autocomplete-parent-scope {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* Footer and sock displayed on multiple pages */
+.nav-container {
+  display: flex;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 36px 0;
+  color: var(--color-white);
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 750px) {
+  .link-list {
+    width: 100%;
+  }
+}
+
+.main-footer {
+  background-color: var(--color-primary-blue-04);
+  width: 864px;
+}
+
+.link-list {
+  padding: 0 36px;
+}
+
+.link-list ul {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+/* Footer links: U/Body/Link */
+.main-footer li a {
+  color: var(--color-white);
+  font-family: proxima-nova;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 200;
+  line-height: 120%;
+}
+
+.main-footer li {
+  list-style: none;
+  padding: 4px 0;
+}
+
+/* Footer headings: no named style */
+.main-footer h3 {
+  color: var(--color-white);
+  font-family: Karbon;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 120%;
+  letter-spacing: 2.4px;
+  text-transform: uppercase;
+}
+
+.sock-content {
+  color: var(--color-secondary-grey-04);
+  font-family: Karbon;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 160%;
+  letter-spacing: 0.16px;
+}
+
+.sock-list {
+  display: flex;
+  gap: 48px;
+  flex-wrap: wrap;
+}
+/* Sock links: no named style */
+.sock-list li a {
+  color: var(--color-black);
+  font-family: Karbon;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 100%;
+  letter-spacing: 0.16px;
+  text-decoration: underline;
+  text-decoration-color: var(--color-default-cyan-03);
+}
+
+.sock .nav-container {
+  padding: 32px 0;
+  align-items: center;
 }

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/search.css
@@ -503,3 +503,81 @@ prm-browse-search md-content {
 .sidebar-section .text-in-brackets::after {
   font-style: italic;
 }
+
+/* Remove and restyle elements so results cards can span whole width */
+#fixed-buttons-holder {
+  display: none;
+}
+
+md-content {
+  padding: 0 !important;
+}
+
+md-content flex-order-4:nth-child(3) {
+  display: none;
+}
+
+/* Bottom banner - "Can't find what you're looking for?" */
+#search-bottom-banner {
+  width: 864px;
+  height: 225px;
+  background: var(--color-primary-blue-03);
+  position: relative;
+}
+
+#bottom-banner-header {
+  color: var(--color-white);
+  font-size: 40px;
+  font-family: Karbon;
+  font-weight: 400;
+  line-height: 48px;
+}
+
+#bottom-banner-text {
+  color: var(--color-white);
+  font-size: 20px;
+  font-family: Karbon;
+  font-weight: 400;
+  line-height: 32px;
+  letter-spacing: 0.2px;
+}
+
+#bottom-banner-text a {
+  color: var(--color-white);
+  font-size: 20px;
+  font-family: Karbon;
+  font-weight: 400;
+  line-height: 32px;
+  letter-spacing: 0.2px;
+  text-decoration: underline;
+}
+
+.bottom-banner-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.svg__fill-bottom,
+.svg__fill-top,
+.svg__fill-accent {
+  fill: var(--color-primary-blue-02);
+}
+
+.svg__fill-bottom,
+.svg__fill-top {
+  opacity: 0.25;
+}
+
+.svg__fill-accent {
+  opacity: 0.55;
+}
+
+.svg__molecule-half {
+  transform: rotate(180deg);
+  height: 225px;
+  margin-left: -52px;
+  position: absolute;
+}

--- a/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
@@ -717,9 +717,9 @@ app.component("prmAlmaOtherMembersAfter", {
 
     <svg width="225" height="496" viewBox="0 0 225 496" fill="none" xmlns="http://www.w3.org/2000/svg" class="svg__molecule-half">
   <g>
-  <path d="M244.852 445.001L106.511 387.698L71.9262 422.283L244.852 493.911L244.852 445.001Z" fill="#0B6AB7" class="svg__fill-bottom"/>
-  <path d="M71.9261 76.4322L106.511 111.017L244.852 53.7149L244.851 4.80416L71.9261 76.4322Z" fill="#0B6AB7" class="svg__fill-top"/>
-  <path d="M0.297249 249.357L71.9254 76.4319L106.511 111.017L49.2081 249.357L49.208 249.357L106.51 387.698L71.9254 422.283L0.297249 249.357Z" fill="#9ECFFA" class="svg__fill-accent"/>
+  <path d="M244.852 445.001L106.511 387.698L71.9262 422.283L244.852 493.911L244.852 445.001Z" class="svg__fill-bottom"/>
+  <path d="M71.9261 76.4322L106.511 111.017L244.852 53.7149L244.851 4.80416L71.9261 76.4322Z" class="svg__fill-top"/>
+  <path d="M0.297249 249.357L71.9254 76.4319L106.511 111.017L49.2081 249.357L49.208 249.357L106.51 387.698L71.9254 422.283L0.297249 249.357Z" class="svg__fill-accent"/>
   </g>
   </svg>
   <div class="bottom-banner-content">

--- a/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
@@ -303,7 +303,7 @@
                            }
 
                               var elems = institutionFacets.getElementsByClassName('md-chip');
-                              console.log("Elems: ", elems);
+                              //console.log("Elems: ", elems);
                               // turn into a sortable array
                               elems = Array.prototype.slice.call(elems);
                               // Sort it.
@@ -474,18 +474,18 @@
       {
         this.navigateToHomePage = function () {
           var params = $location.search();
-          console.log(params);
+          //console.log(params);
           var vid = params.vid;
           var lang = params.lang || "en_US";
           var split = $location.absUrl().split('/discovery/');
 
           if (split.length === 1) {
-            console.log(split[0] + ' : Could not detect the view name!');
+            //console.log(split[0] + ' : Could not detect the view name!');
             return false;
           }
 
           if ($location.absUrl().match('mode=advanced')) {
-            console.log($location.absUrl().match('mode=advanced') + ' : Detected Advanced Search!');
+            //console.log($location.absUrl().match('mode=advanced') + ' : Detected Advanced Search!');
             return false;
           }
 
@@ -496,18 +496,18 @@
 
         this.showSearchLogo = function() {
           var params = $location.search();
-          console.log(params);
+          //console.log(params);
           var vid = params.vid;
           var lang = params.lang || "en_US";
           var split = $location.absUrl().split('/discovery/');
 
           if (split.length === 1) {
-            console.log(split[0] + ' : Could not detect the view name!');
+            //console.log(split[0] + ' : Could not detect the view name!');
             return false;
           }
 
           if ($location.absUrl().match('mode=advanced')) {
-            console.log($location.absUrl().match('mode=advanced') + ' : Detected Advanced Search!');
+            //console.log($location.absUrl().match('mode=advanced') + ' : Detected Advanced Search!');
             return false;
           }
 
@@ -708,6 +708,34 @@ app.component("prmAlmaOtherMembersAfter", {
   app.component('prmServiceDetailsAfter', {
     bindings: {parentCtrl: `<`},
     template: `<ethical-description-note></ethical-description-note>`    
+  });
+
+  /* "Can't find what you're looking for?" Banner - bottom of search results */
+  app.component('searchBottomBanner', {
+    template: `
+    <div id="search-bottom-banner">
+
+    <svg width="225" height="496" viewBox="0 0 225 496" fill="none" xmlns="http://www.w3.org/2000/svg" class="svg__molecule-half">
+  <g>
+  <path d="M244.852 445.001L106.511 387.698L71.9262 422.283L244.852 493.911L244.852 445.001Z" fill="#0B6AB7" class="svg__fill-bottom"/>
+  <path d="M71.9261 76.4322L106.511 111.017L244.852 53.7149L244.851 4.80416L71.9261 76.4322Z" fill="#0B6AB7" class="svg__fill-top"/>
+  <path d="M0.297249 249.357L71.9254 76.4319L106.511 111.017L49.2081 249.357L49.208 249.357L106.51 387.698L71.9254 422.283L0.297249 249.357Z" fill="#9ECFFA" class="svg__fill-accent"/>
+  </g>
+  </svg>
+  <div class="bottom-banner-content">
+    <span id="bottom-banner-header">
+    Can’t find what you’re looking for?</span>
+    <span id="bottom-banner-text">
+    Try applying the filters, 
+    using an <a href="http://localhost:8003/discovery/search?vid=01UCS_LAL:PRIMO_REDESIGN&lang=en&mode=advanced">advanced search</a>, 
+    or changing your <a href="https://guides.library.ucla.edu/Search/Scopes">search scope.</a></span>
+</div></div></div>
+`
+  });
+
+  app.component('prmPageNavMenuAfter', {
+    bindings: {parentCtrl: `<`},
+    template: `<search-bottom-banner></search-bottom-banner>`    
   });
 }());
 

--- a/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/js/custom.js
@@ -729,7 +729,63 @@ app.component("prmAlmaOtherMembersAfter", {
     Try applying the filters, 
     using an <a href="http://localhost:8003/discovery/search?vid=01UCS_LAL:PRIMO_REDESIGN&lang=en&mode=advanced">advanced search</a>, 
     or changing your <a href="https://guides.library.ucla.edu/Search/Scopes">search scope.</a></span>
-</div></div></div>
+  </div></div></div>
+  <footer>
+      <div class="main-footer">
+          <div class="nav-container">
+              <div class="link-list">
+                  <h3>Search</h3>
+                  <ul>
+                      <li><a href="https://www.library.ucla.edu/">New Search</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Advanced Search</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Course Reserves</a></li>
+                      <li><a href="https://www.library.ucla.edu/">About Search Scopes</a></li>
+                  </ul>
+              </div>
+              <div class="link-list">
+                  <h3>Account</h3>
+                  <ul>
+                      <li><a href="https://www.library.ucla.edu/">My Library Account</a></li>
+                      <li><a href="https://www.library.ucla.edu/">My Loans</a></li>
+                      <li><a href="https://www.library.ucla.edu/">My Requests</a></li>
+                      <li><a href="https://www.library.ucla.edu/">My Favorites</a></li>
+                  </ul>
+              </div>
+              <div class="link-list">
+                  <h3>Help</h3>
+                  <ul>
+                      <li><a href="https://www.library.ucla.edu/">Ask a Librarian</a></li> 
+                      <li><a href="https://www.library.ucla.edu/">Guide to UC Library Search</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Guide to Logging In</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Research Guides</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Help with VPN</a></li>
+                  </ul>
+              </div>
+              <div class="link-list">
+                  <h3>More Resources</h3>
+                  <ul>
+                      <li><a href="https://www.library.ucla.edu/">VPN Client</a></li>
+                      <li><a href="https://www.library.ucla.edu/">ILL Request</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Research Guides</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Databases</a></li>
+                      <li><a href="https://www.library.ucla.edu/">Primary Sources</a></li>
+                  </ul>
+              </div>
+          </div>
+      </div>
+      <div class="sock">
+          <div class="nav-container">
+              <div class="sock-content">
+                  <span>© 2021 Regents of the University of California</span>
+              </div>
+              <ul class="sock-list">
+                  <li><a href="https://www.library.ucla.edu/">Emergency</a></li>
+                  <li><a href="https://www.library.ucla.edu/">Accessibility</a></li>
+                  <li><a href="https://www.library.ucla.edu/">Privacy & Terms of Use</a></li>
+              </ul>
+          </div>
+      </div>
+  </footer>
 `
   });
 
@@ -738,4 +794,5 @@ app.component("prmAlmaOtherMembersAfter", {
     template: `<search-bottom-banner></search-bottom-banner>`    
   });
 }());
+
 


### PR DESCRIPTION
Implements [SYS-1467](https://uclalibrary.atlassian.net/browse/SYS-1467)
Available in the dev Primo view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:PRIMO_REDESIGN

This PR adds three "footers" to Primo search results as specified in the [Figma design](https://www.figma.com/file/R6n38mi5qmVnkS4FWHhrLS/Feature-Redesigns?node-id=2727%3A9187&mode=dev): a "Can't find what you're looking for?" banner intended only for search result pages, plus a generic "footer" and "sock" with helpful links that will eventually be displayed on many pages in Primo.

This is accomplished with the new `searchBottomBanner` component, inserted into Primo's `prmPageNavMenuAfter` component via `custom.js`. This one component contains all three "footers" in its template.

I was not able to use a hosted SVG asset for the polygon image at the top of the banner, as the colors in the design are not identical to any of the versions we have in the Design Tokens repo. Therefore we needed to include all the individual paths so they could be styled with CSS.

The relevant CSS for this change is split across two files: `search.css` for the topmost footer styling, which will only appear on search result pages, and `main.css` for the others which will eventually be reused.

[SYS-1467]: https://uclalibrary.atlassian.net/browse/SYS-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ