### PR TITLE
SYS-1482: Improve fines and fees display

### DIFF
--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/account.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/account.css
@@ -125,6 +125,11 @@ prm-fines div.header-subtitle > span > em:first-child {
   text-transform: uppercase;
 }
 
+/* Account -> Fines + Fees: Align balance and link to payment button. */
+prm-fines div.header-subtitle {
+  display: flex;
+}
+
 /* Account > Fines + Fees: item amount : U/Max/Heading/Step1  */
 prm-fines
   md-list
@@ -142,6 +147,7 @@ prm-fines
 }
 
 /* Account > Fines + Fees: labels: U/Body/Overline */
+/* Bump font-size from 16px to 18px per discussions. */
 prm-fines
   md-list
   md-list-item
@@ -151,7 +157,7 @@ prm-fines
   > span:first-child {
   color: var(--color-black);
   font-family: Karbon;
-  font-size: 16px;
+  font-size: 18px;
   font-style: normal;
   font-weight: 500;
   line-height: 160%;
@@ -174,4 +180,24 @@ prm-fines
   font-weight: 400;
   line-height: 160%;
   letter-spacing: 0.2px;
+}
+
+/* Account > Fines + Fees: Allow long titles to wrap */
+prm-fines md-list md-list-item h4 {
+  white-space: unset !important;
+}
+
+/* Account > Fines + Fees: Enforce 2-column display of data for all cards */
+div.flex-xs-100.flex {
+  min-width: unset;
+}
+
+/* Account -> Fines + Fees: U/Body/Button for link to payment page */
+.tab-content-header .md-button.button-as-link {
+  color: var(--color-black);
+  font-family: Proxima Nova;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 120%;
 }

--- a/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/account.css
+++ b/views/01UCS_LAL-PRIMO_REDESIGN/css/ucla/account.css
@@ -195,7 +195,7 @@ div.flex-xs-100.flex {
 /* Account -> Fines + Fees: U/Body/Button for link to payment page */
 .tab-content-header .md-button.button-as-link {
   color: var(--color-black);
-  font-family: Proxima Nova;
+  font-family: proxima-nova;
   font-size: 18px;
   font-style: normal;
   font-weight: 400;


### PR DESCRIPTION
Implements [SYS-1482](https://uclalibrary.atlassian.net/browse/SYS-1482).

This PR makes a few improvements to the Fines and Fees page:
* Change "Pay Fine" link text to match design
* Align "Pay Fine" with "Current Fines Balance" text
* Wrap long title lines in each fine as needed
* Maintain consistent 2-column layout for fines
* Increase fine label text from 16px to 18px

All changes are in `account.css`, in the `PRIMO_REDESIGN` view only.


[SYS-1482]: https://uclalibrary.atlassian.net/browse/SYS-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ