### PR TITLE
SYS-1541: Primo view changes for bookplates

### DIFF
--- a/views/01UCS_LAL-UCLA/css/custom1.css
+++ b/views/01UCS_LAL-UCLA/css/custom1.css
@@ -155,6 +155,10 @@ div.search-actions button.md-button.button-confirm prm-icon {
   box-shadow: none;
   text-decoration: underline;
 }
+/* prevent bookplate from being hidden on hover in search results */
+prm-search-result-journal-indication-line {
+  z-index: 1;
+}
 
 div.full-view-section {
   margin-top: 0 !important;

--- a/views/01UCS_LAL-UCLA/css/custom1.css
+++ b/views/01UCS_LAL-UCLA/css/custom1.css
@@ -147,27 +147,15 @@ div.search-actions button.md-button.button-confirm prm-icon {
 
 /*bookplate*/
 .bookplate {
-  background-color: var(--color-primary-blue-04);
-  text-align: center;
-  color: var(--color-white);
-  width: 200px;
-  height: 300px;
-  font-family: Didot, serif;
-  border: 3px double white;
-}
-button.bookplateBtn {
-  border: 1px solid var(--color-primary-blue-04);
-}
-.bookplateLink {
   display: table;
-  padding: 5px;
-  border: 2px solid var(--color-secondary-yellow-600);
+  margin: auto 0;
 }
-.bookplateLinkText {
-  display: table-cell;
-  vertical-align: middle;
-  font-weight: bold;
+
+.bookplateLink:hover {
+  box-shadow: none;
+  text-decoration: underline;
 }
+
 div.full-view-section {
   margin-top: 0 !important;
 }

--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -729,11 +729,11 @@ app.component("prmAlmaOtherMembersAfter", {
 
       //Check whether the bookplate exists
       $scope.hasBookplate = function() {
-        // first check if the field exists
-        if (bookplates != null && bookplates != ''){
+        if (bookplates != null && bookplates != '') {
           return true;
         }
-        return false; }   
+        return false; 
+      }   
 
       // Get URLs for bookplate links - last space-delimited "word" in each string
       $scope.getBookplateLink = function(bookplate) {
@@ -756,7 +756,8 @@ app.component("prmAlmaOtherMembersAfter", {
   app.component('bookplateComponent', {
     bindings: { parentCtrl: '<'},
     controller: 'bookplateController',
-    template: '<div class="bookplate" ng-if="hasBookplate()" ng-repeat="bookplate in bookplates"> Provided by: <a href="{{getBookplateLink(bookplate)}}" class="bookplateLink">{{getBookplateText(bookplate)}}</a></div>'
+    template: `<div class="bookplate" ng-if="hasBookplate()" ng-repeat="bookplate in bookplates">
+    Provided by: <a href="{{getBookplateLink(bookplate)}}" class="bookplateLink">{{getBookplateText(bookplate)}}</a></div>`
   });
 
 }());

--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -496,7 +496,7 @@
 
         this.showSearchLogo = function() {
           var params = $location.search();
-          console.log(params);
+          //console.log(params);
           var vid = params.vid;
           var lang = params.lang || "en_US";
           var split = $location.absUrl().split('/discovery/');
@@ -727,14 +727,6 @@ app.component("prmAlmaOtherMembersAfter", {
       let bookplates = $scope.display.lds36;
       $scope.bookplates = bookplates;
 
-      //Check whether the bookplate exists
-      $scope.hasBookplate = function() {
-        if (bookplates != null && bookplates != '') {
-          return true;
-        }
-        return false; 
-      }   
-
       // Get URLs for bookplate links - last space-delimited "word" in each string
       $scope.getBookplateLink = function(bookplate) {
         return bookplate.split(" ").slice(-1)[0];
@@ -756,8 +748,8 @@ app.component("prmAlmaOtherMembersAfter", {
   app.component('bookplateComponent', {
     bindings: { parentCtrl: '<'},
     controller: 'bookplateController',
-    template: `<div class="bookplate" ng-if="hasBookplate()" ng-repeat="bookplate in bookplates">
-    Provided by: <a href="{{getBookplateLink(bookplate)}}" class="bookplateLink">{{getBookplateText(bookplate)}}</a></div>`
+    template: `<div class="bookplate" ng-repeat="bookplate in bookplates">
+    Provided by: <a target="_blank" href="{{getBookplateLink(bookplate)}}" class="bookplateLink">{{getBookplateText(bookplate)}}</a></div>`
   });
 
 }());

--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -742,7 +742,7 @@ app.component("prmAlmaOtherMembersAfter", {
   // JournalIndicationLine component appears on both brief (search result) and full display, regardless of media type
   app.component('prmSearchResultJournalIndicationLineAfter', {
     bindings: { parentCtrl: '<'},
-    template: '<bookplate-component parent-ctrl="$ctrl.parentCtrl"></bookplate-component>'
+    template: '<bookplate-component ng-click="$event.stopPropagation();" parent-ctrl="$ctrl.parentCtrl"></bookplate-component>'
   });
 
   app.component('bookplateComponent', {

--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -711,5 +711,53 @@ app.component("prmAlmaOtherMembersAfter", {
     bindings: {parentCtrl: `<`},
     template: `<ethical-description-note></ethical-description-note>`    
   });
+
+
+  /* E-Bookplates */
+  app.controller('bookplateController', ['$scope', function($scope){
+    var vm = this;
+    this.$onInit = function() {
+      $scope.display = vm.parentCtrl.item.pnx.display;
+      // Get bookplate from Local Display Field 36 "Bookplate"
+      // This is an array, each element is a bookplate
+      // Each bookplate is a concatenation of the 966 $b and $c fields
+      // For example: 
+      // lds36: Array [ "Bookplate Label #1 https://example.com", "Bookplate Label #2 https://another-example.com" ]
+      // With our normalization rules, only bookplates with URLs will be in the array
+      let bookplates = $scope.display.lds36;
+      $scope.bookplates = bookplates;
+
+      //Check whether the bookplate exists
+      $scope.hasBookplate = function() {
+        // first check if the field exists
+        if (bookplates != null && bookplates != ''){
+          return true;
+        }
+        return false; }   
+
+      // Get URLs for bookplate links - last space-delimited "word" in each string
+      $scope.getBookplateLink = function(bookplate) {
+        return bookplate.split(" ").slice(-1)[0];
+      }
+    
+      // Get wording for specific bookplate display text - all but the last "word"
+      $scope.getBookplateText = function(bookplate) {
+        return bookplate.split(" ").slice(0,-1).join(" ");
+      }
+    };
+  }]);
+  
+  // JournalIndicationLine component appears on both brief (search result) and full display, regardless of media type
+  app.component('prmSearchResultJournalIndicationLineAfter', {
+    bindings: { parentCtrl: '<'},
+    template: '<bookplate-component parent-ctrl="$ctrl.parentCtrl"></bookplate-component>'
+  });
+
+  app.component('bookplateComponent', {
+    bindings: { parentCtrl: '<'},
+    controller: 'bookplateController',
+    template: '<div class="bookplate" ng-if="hasBookplate()" ng-repeat="bookplate in bookplates"> Provided by: <a href="{{getBookplateLink(bookplate)}}" class="bookplateLink">{{getBookplateText(bookplate)}}</a></div>'
+  });
+
 }());
 


### PR DESCRIPTION
Implements [SYS-1541](https://uclalibrary.atlassian.net/browse/SYS-1541)

Available in a test view (in Sandbox): https://ucla-psb.primo.exlibrisgroup.com/discovery/search?vid=01UCS_LAL:UCLA_SYS_1541
Direct link to a sample record: https://ucla-psb.primo.exlibrisgroup.com/permalink/01UCS_LAL/1i3fkrn/alma993535723606533
This record has three 966s, two of which have a URL in $c and thus should be visible as bookplates. Bookplates should be visible at the top of full record displays and within search results.

The below normalization rule creates the Local Display Field 36 used by `custom.js` to create bookplates. Since the rule only includes 966s with $c in the field Lds36, our JS can assume that all Lds36s are valid bookplates for display.

```
rule "Primo VE - Lds36"
	when
		MARC."966" has any "c"
	then
		create pnx."display"."lds36" with MARC."966" subfields "b,c"
end
```

[SYS-1541]: https://uclalibrary.atlassian.net/browse/SYS-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ