### PR TITLE
DFG-134: make SRLF Request button more visible

### DIFF
--- a/views/01UCS_LAL-UCLA/css/custom1.css
+++ b/views/01UCS_LAL-UCLA/css/custom1.css
@@ -625,3 +625,10 @@ md-input-container .md-input,
 #speedDialWidget.page-nav {
   bottom: 80px !important;
 }
+
+/* Make SRLF "Request" link more visible */
+prm-service-button span[translate="AlmaRequest"] {
+  font-weight: bold;
+  text-decoration: underline;
+  font-size: 1.3em;
+}


### PR DESCRIPTION
Implements [DFG-134](https://uclalibrary.atlassian.net/browse/DFG-134)

A small CSS change to make the Request link for SRLF materials larger, bold, and underlined. Available in a test view: [direct link to SRLF record](https://search.library.ucla.edu/permalink/01UCS_LAL/p9j0c0/alma9911130533606533). Log in to see the Request button under "How to get it".

[DFG-134]: https://uclalibrary.atlassian.net/browse/DFG-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ