### PR TITLE
SYS-1682: add cost survey script to production Primo

### DIFF
--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -752,5 +752,20 @@ app.component("prmAlmaOtherMembersAfter", {
     Provided by: <a target="_blank" href="{{getBookplateLink(bookplate)}}" class="bookplateLink">{{getBookplateText(bookplate)}}</a></div>`
   });
 
+  // Library Cost Analysis script
+  app.controller("costAnalysisController", [
+    "$scope",
+    function () {
+      var s = document.createElement("script");
+      s.type = "text/javascript";
+      s.src = "https://librarystudy.library.ucla.edu/gsurvey.js";
+      document.head.appendChild(s);
+    },
+  ]);
+  app.component("prmTopBarBefore", {
+    bindings: { parentCtrl: "<" },
+    controller: "costAnalysisController",
+  });
+
 }());
 


### PR DESCRIPTION
Implements [SYS-1682](https://uclalibrary.atlassian.net/browse/SYS-1682)

Adds the production version of the cost survey script (`https://librarystudy.library.ucla.edu/gsurvey.js`) to Primo. Already deployed to [production Primo](https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA) and approved by consultant.

[SYS-1682]: https://uclalibrary.atlassian.net/browse/SYS-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ