### PR TITLE
SYS-1724: Enable broader emergency access to HathiTrust materials

### DIFF
--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -102,9 +102,9 @@
     var formatLink = function formatLink(link) {
       if ( link.match(/_PD$/i) ){
         link = link.substring(0, link.length - 3);
-        self.fullTextLinkMsg = 'Available online with HathiTrust - Public Domain Access';
+        self.fullTextLinkMsg = 'Available online with HathiTrust';
       } else {
-        self.fullTextLinkMsg = 'Error - ' + link;
+        self.fullTextLinkMsg = 'Available online with HathiTrust';
       }
       return link;
     };
@@ -575,7 +575,7 @@
   app.component('prmSearchResultAvailabilityLineAfter', {
     bindings: { parentCtrl: '<'},
     controller: 'digitalBookTitleButtonController',
-    template: '<hathi-trust-availability entity-id="urn:mace:incommon:ucla.edu" msg="Available online with HathiTrust - UCLA Access"></hathi-trust-availability>'
+    template: '<hathi-trust-availability entity-id="urn:mace:incommon:ucla.edu" msg="Available online with HathiTrust - UCLA Access" ignore-copyright="true"></hathi-trust-availability>'
   });
 
   /* UC Library Search Logo */


### PR DESCRIPTION
Implements [SYS-1724](https://uclalibrary.atlassian.net/browse/SYS-1724).

This PR enables broader access to materials via HathiTrust.  Two changes:
* add `ignore-copyright="true"` to the template
* change the message showing in Primo, to quickly work around differences between how public domain and limited access materials display

**REMINDER**: When this gets turned off, be sure the original message code in `formatLink()` is restored.

Sample links:
* https://search.library.ucla.edu/permalink/01UCS_LAL/trta7g/alma9922388023606533 (ETAS access now enabled)
* https://search.library.ucla.edu/permalink/01UCS_LAL/trta7g/alma991323253606533 (Public domain always enabled)


[SYS-1724]: https://uclalibrary.atlassian.net/browse/SYS-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ