### PR TITLE
SYS-1725: Revert HathiTrust emergency access

### DIFF
--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -102,9 +102,9 @@
     var formatLink = function formatLink(link) {
       if ( link.match(/_PD$/i) ){
         link = link.substring(0, link.length - 3);
-        self.fullTextLinkMsg = 'Available online with HathiTrust';
+        self.fullTextLinkMsg = 'Available online with HathiTrust - Public Domain Access';
       } else {
-        self.fullTextLinkMsg = 'Available online with HathiTrust';
+        self.fullTextLinkMsg = 'Error - ' + link;
       }
       return link;
     };
@@ -575,7 +575,7 @@
   app.component('prmSearchResultAvailabilityLineAfter', {
     bindings: { parentCtrl: '<'},
     controller: 'digitalBookTitleButtonController',
-    template: '<hathi-trust-availability entity-id="urn:mace:incommon:ucla.edu" msg="Available online with HathiTrust - UCLA Access" ignore-copyright="true"></hathi-trust-availability>'
+    template: '<hathi-trust-availability entity-id="urn:mace:incommon:ucla.edu" msg="Available online with HathiTrust - UCLA Access"></hathi-trust-availability>'
   });
 
   /* UC Library Search Logo */


### PR DESCRIPTION
Implements [SYS-1725](https://uclalibrary.atlassian.net/browse/SYS-1725).

This reverts commit 96d536122c007799276a3a67f5df7c86c5e0caf5, removing the HathiTrust emergency access.


[SYS-1725]: https://uclalibrary.atlassian.net/browse/SYS-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ