### PR TITLE
SYS-1837: update search scope list on Primo homepage

### DIFF
--- a/views/01UCS_LAL-UCLA/html/homepage/homepage_en.html
+++ b/views/01UCS_LAL-UCLA/html/homepage/homepage_en.html
@@ -23,7 +23,13 @@ Here you can search for books and e-books, videos/films, articles, digital media
     <td><b>UCLA Library Catalog</b> (excluding articles)</td>
   </tr>
   <tr>
-    <td><b>UCLA Film & Television Archive</b> (media from the Archive)</td>
+    <td><b>UCLA Film & Television Archive</b> (media from the <a href="https://cinema.ucla.edu">Archive</a>)</td>
+  </tr>
+  <tr>
+    <td><b>Library Special Collections (YRL)</b> (resources held by <a href="https://library.ucla.edu/visit/locations/library-special-collections">Library Special Collections</a>)</td>
+  </tr>
+  <tr>
+    <td><b>Clark Library</b> (resources held by the <a href="https://clarklibrary.ucla.edu">Clark Library</a>)</td>
   </tr>
   <tr>
     <td><b>WorldCat Global Catalog</b> (resources outside UC)</td>


### PR DESCRIPTION
Implements [SYS-1837](https://uclalibrary.atlassian.net/browse/SYS-1837)

Available in a test view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_1837

Adds the two recently-added search scopes (LSC and Clark) to the list on the Primo homepage.

To give users more context for the scopes, I added links to the FTVA, LSC, and Clark websites/pages. These will need to be updated if these pages move, but we'll be revisiting the homepage anyway during the NDE transition (starting November 2025).

<img width="534" alt="image" src="https://github.com/user-attachments/assets/27f4682c-cd75-41c6-b186-20fb2a0be8f2" />

[SYS-1837]: https://uclalibrary.atlassian.net/browse/SYS-1837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ