### PR TITLE
SYS-2041: update 'harmful language' statement

### DIFF
--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -702,7 +702,7 @@ app.component("prmAlmaOtherMembersAfter", {
     style="border: 2px solid var(--color-primary-blue-04); border-radius: 3px; text-align:left; padding:4px;">
       <span class="bar-text">We are committed to updating our catalog records and finding aids whenever feasible 
       to revise problematic descriptions and subjects, including the addition of relevant context.
-      <b>To report harmful language, please use 
+      <b>To report an issue, including harmful language, please use 
       <a href="https://ucla.libwizard.com/id/38f45c482a5fcb0b715a7e9e3ddee8b2" target="_blank" rel="noopener noreferrer">this form</a>.</b> 
       </span></div>`
   });


### PR DESCRIPTION
Implements [SYS-2041](https://uclalibrary.atlassian.net/browse/SYS-2041)

Available in a [test view](https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_2041)

Updates the second sentence of the "harmful language" statement on individual record pages, as described in the Jira ticket.

[SYS-2041]: https://uclalibrary.atlassian.net/browse/SYS-2041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ