### PR TITLE
SYS-2114: remove cost survey script from Primo

### DIFF
--- a/views/01UCS_LAL-UCLA/js/custom.js
+++ b/views/01UCS_LAL-UCLA/js/custom.js
@@ -752,20 +752,6 @@ app.component("prmAlmaOtherMembersAfter", {
     Provided by: <a target="_blank" href="{{getBookplateLink(bookplate)}}" class="bookplateLink">{{getBookplateText(bookplate)}}</a></div>`
   });
 
-  // Library Cost Analysis script
-  app.controller("costAnalysisController", [
-    "$scope",
-    function () {
-      var s = document.createElement("script");
-      s.type = "text/javascript";
-      s.src = "https://librarystudy.library.ucla.edu/gsurvey.js";
-      document.head.appendChild(s);
-    },
-  ]);
-  app.component("prmTopBarBefore", {
-    bindings: { parentCtrl: "<" },
-    controller: "costAnalysisController",
-  });
 
 }());
 


### PR DESCRIPTION
Implements [SYS-2114](https://uclalibrary.atlassian.net/browse/SYS-2114)
Available in a test Primo view: https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA_SYS_2114

A simple change to remove the Cost Analysis script from Primo. The test view should function identically to the [production view](https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA), but you can see that the script is no longer pulled in by using the Firefox JS debugger.

Before:
<img width="489" height="256" alt="image" src="https://github.com/user-attachments/assets/cf5b41fc-1b54-429e-bb65-8a7ede4ae609" />

After:
<img width="489" height="256" alt="image" src="https://github.com/user-attachments/assets/038f0aef-a996-4026-b476-a72097dd94f0" />



[SYS-2114]: https://uclalibrary.atlassian.net/browse/SYS-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ